### PR TITLE
Add virtual PlatformIO tests

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.cpp
@@ -45,4 +45,8 @@ namespace SwitchHandler {
             sw.update();
         }
     }
+
+    void reset() {
+        switches.clear();
+    }
 }

--- a/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.h
+++ b/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.h
@@ -20,4 +20,5 @@ private:
 namespace SwitchHandler {
     void addSwitch(int pin, Switch::Callback callback);
     void updateAll();
+    void reset();
 }

--- a/Ground Control Station/BottomPanelCode/platformio.ini
+++ b/Ground Control Station/BottomPanelCode/platformio.ini
@@ -52,4 +52,10 @@ build_flags =
 	-D USBCON
 	-D HAL_PCD_MODULE_ENABLED
 	-D ARDUINO_ARCH_AVR
-	-D DEBUG_HID
+        -D DEBUG_HID
+
+[env:native]
+platform = native
+test_build_project_src = false
+build_flags = -D DEBUG_HID -I test/stubs -I lib/pins
+lib_ignore = Blinker, leds, pins, Switches

--- a/Ground Control Station/BottomPanelCode/test/stubs/Adafruit_MCP23X17.h
+++ b/Ground Control Station/BottomPanelCode/test/stubs/Adafruit_MCP23X17.h
@@ -1,0 +1,10 @@
+#ifndef ADAFRUIT_MCP23X17_H
+#define ADAFRUIT_MCP23X17_H
+class Adafruit_MCP23X17 {
+public:
+    void begin_I2C(int addr = 0){ (void)addr; }
+    void pinMode(int pin, int mode){ (void)pin; (void)mode; }
+    void digitalWrite(int pin, int val){ (void)pin; (void)val; }
+    int digitalRead(int pin){ (void)pin; return 0; }
+};
+#endif

--- a/Ground Control Station/BottomPanelCode/test/stubs/Arduino.h
+++ b/Ground Control Station/BottomPanelCode/test/stubs/Arduino.h
@@ -1,0 +1,32 @@
+#ifndef ARDUINO_H
+#define ARDUINO_H
+
+#include <map>
+
+#define HIGH 1
+#define LOW 0
+#define INPUT 0
+#define INPUT_PULLUP 2
+#define OUTPUT 1
+
+inline std::map<int,int>& _pinState() {
+    static std::map<int,int> state;
+    return state;
+}
+
+inline void pinMode(int pin, int mode) { (void)pin; (void)mode; }
+
+inline int digitalRead(int pin) {
+    auto& s = _pinState();
+    auto it = s.find(pin);
+    if(it == s.end()) return LOW;
+    return it->second;
+}
+
+inline void digitalWrite(int pin, int val) {
+    _pinState()[pin] = val;
+}
+
+inline void setPinState(int pin, int val) { _pinState()[pin] = val; }
+
+#endif // ARDUINO_H

--- a/Ground Control Station/BottomPanelCode/test/stubs/SPI.h
+++ b/Ground Control Station/BottomPanelCode/test/stubs/SPI.h
@@ -1,0 +1,4 @@
+#ifndef SPI_H
+#define SPI_H
+class SPIClass { public: SPIClass(int mosi=0,int miso=0,int sck=0){} void begin(){} };
+#endif

--- a/Ground Control Station/BottomPanelCode/test/stubs/Wire.h
+++ b/Ground Control Station/BottomPanelCode/test/stubs/Wire.h
@@ -1,0 +1,5 @@
+#ifndef WIRE_H
+#define WIRE_H
+class TwoWire { public: void begin(){} };
+static TwoWire Wire;
+#endif

--- a/Ground Control Station/BottomPanelCode/test/stubs/pins.h
+++ b/Ground Control Station/BottomPanelCode/test/stubs/pins.h
@@ -1,0 +1,4 @@
+#ifndef PINS_H
+#define PINS_H
+// Minimal stub for tests
+#endif

--- a/Ground Control Station/BottomPanelCode/test/test_switchhandler/test_main.cpp
+++ b/Ground Control Station/BottomPanelCode/test/test_switchhandler/test_main.cpp
@@ -1,0 +1,35 @@
+#include <Arduino.h>
+#include <unity.h>
+#include <SwitchHandler.h>
+
+static bool callbackState = false;
+
+void test_callback(bool state){
+    callbackState = state;
+}
+
+void setUp(void){
+    callbackState = false;
+    setPinState(5, LOW);
+    SwitchHandler::reset();
+    SwitchHandler::addSwitch(5, test_callback);
+}
+
+void tearDown(void){ }
+
+void test_switch_changes(){
+    // initial state LOW -> no callback yet
+    SwitchHandler::updateAll();
+    TEST_ASSERT_FALSE(callbackState);
+
+    // change state to HIGH
+    setPinState(5, HIGH);
+    SwitchHandler::updateAll();
+    TEST_ASSERT_TRUE(callbackState);
+}
+
+int main(int argc, char **argv){
+    UNITY_BEGIN();
+    RUN_TEST(test_switch_changes);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- enable unit tests via a new native environment
- provide stubs for Arduino and hardware headers
- add reset function to SwitchHandler for tests
- include a sample SwitchHandler unit test

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6872b355cb348332afc922220863bd3e