### PR TITLE
Add warning mode to ScreenPowerSwitch

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
@@ -101,8 +101,41 @@ void ScreenPowerSwitch::begin() {
     drawSwitchArm(-45, ST77XX_YELLOW, true);
 }
 
+void ScreenPowerSwitch::drawWarningIcon(bool visible) {
+    uint16_t color = visible ? ST77XX_RED : ST77XX_BLACK;
+    tft.setTextSize(4);
+    tft.setTextColor(color, ST77XX_BLACK);
+    tft.setCursor(centerX - 12, centerY - 16);
+    tft.print("!");
+}
+
+void ScreenPowerSwitch::showWarning() {
+    warningMode = true;
+    tft.fillScreen(ST77XX_BLACK);
+    warningVisible = true;
+    lastBlink = millis();
+    drawWarningIcon(true);
+}
+
+void ScreenPowerSwitch::showMainScreen() {
+    warningMode = false;
+    tft.fillScreen(ST77XX_BLACK);
+    drawIcons();
+    int angle = (currentPower == BATTERY) ? -45 : 45;
+    drawSwitchArm(angle, ST77XX_YELLOW, true);
+}
+
 void ScreenPowerSwitch::update() {
     unsigned long now = millis();
+
+    if (warningMode) {
+        if (now - lastBlink > warningBlinkInterval) {
+            warningVisible = !warningVisible;
+            drawWarningIcon(warningVisible);
+            lastBlink = now;
+        }
+        return;
+    }
 
     if (now - lastSwitch > switchInterval) {
         PowerSource next = (currentPower == BATTERY) ? PLUG : BATTERY;

--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.h
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.h
@@ -16,6 +16,8 @@ class ScreenPowerSwitch {
 public:
     void begin();
     void update();
+    void showWarning();
+    void showMainScreen();
 
 private:
     enum PowerSource { BATTERY, PLUG };
@@ -38,6 +40,14 @@ private:
 
     float vBat = 11.4;
     float vPlug = 15;
+
+    // Warning screen state
+    bool warningMode = false;
+    bool warningVisible = false;
+    unsigned long lastBlink = 0;
+    static const unsigned long warningBlinkInterval = 500; // ms
+
+    void drawWarningIcon(bool visible);
 
     float simulateVoltage(float base, int variation = 100);
     void drawBatteryIcon(int x, int y, bool active);


### PR DESCRIPTION
## Summary
- add showWarning/showMainScreen methods
- support blinking red exclamation mark on the display
- keep original display easy to restore

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6872c688018c83328a8a0b0394cc779f