### PR TITLE
Verbeterde TFT weergave zonder knipperen

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
@@ -249,10 +249,6 @@ void ScreenPowerSwitch::showWarning() {
     warningMode = true;
     lockMode = false;
     tft.fillScreen(ST77XX_BLACK);
-    warningVisible = true;
-    lastBlink = millis();
-    lastPulse = millis();
-    pulseWhite = false;
     drawWarningIcon(true);
 }
 
@@ -275,26 +271,7 @@ void ScreenPowerSwitch::showLockScreen() {
 void ScreenPowerSwitch::update() {
     unsigned long now = millis();
 
-    if (warningMode) {
-        bool redraw = false;
-        if (now - lastPulse > warningPulseInterval) {
-            pulseWhite = !pulseWhite;
-            redraw = true;
-            lastPulse = now;
-        }
-        if (now - lastBlink > warningBlinkInterval) {
-            warningVisible = !warningVisible;
-            redraw = true;
-            lastBlink = now;
-        }
-        if (redraw) {
-            tft.fillScreen(pulseWhite ? ST77XX_WHITE : ST77XX_BLACK);
-            drawWarningIcon(warningVisible);
-        }
-        return;
-    }
-
-    if (lockMode) {
+    if (warningMode || lockMode) {
         return;
     }
 

--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.h
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.h
@@ -42,14 +42,8 @@ private:
     float vBat = 11.4;
     float vPlug = 15;
 
-    // Warning screen state
+    // Warning and lock screen state
     bool warningMode = false;
-    bool warningVisible = false;
-    unsigned long lastBlink = 0;
-    unsigned long lastPulse = 0;
-    bool pulseWhite = false;
-    static const unsigned long warningBlinkInterval = 200; // ms
-    static const unsigned long warningPulseInterval = 100; // ms
     bool lockMode = false;
 
     static const uint8_t lockBitmap[];


### PR DESCRIPTION
## Samenvatting
- verwijder overbodige knipperlogica in `ScreenPowerSwitch`
- toon waarschuwing statisch en voer alleen hertekenen uit wanneer nodig

## Testinstructies
- `platformio run -e blackpill_f411ce`

------
https://chatgpt.com/codex/tasks/task_e_6873a89e3cf08332b1784aeb9fc68a2c