### PR TITLE
Add PWM fan control via PCA9685

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/TempSensors/TempSensors.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/TempSensors/TempSensors.cpp
@@ -1,29 +1,61 @@
 #include "TempSensors.h"
+#include "leds.h"
 
-const uint8_t TempSensors::sensorPins[4] = {
+const uint8_t TempSensors::sensorPins[NUM_SENSORS] = {
     PIN_SENS2,
     PIN_SENS3,
     PIN_SENS4,
     PIN_SENS5
 };
 
+const TempSensors::FanMapping TempSensors::fanMap[NUM_FANS] = {
+    {FAN1_PWM_CH, 0, 40.0f, 60.0f},
+    {FAN2_PWM_CH, 1, 40.0f, 60.0f}
+};
+
 void TempSensors::begin() {
-    for (uint8_t i = 0; i < 4; ++i) {
+    for (uint8_t i = 0; i < NUM_SENSORS; ++i) {
         pinMode(sensorPins[i], INPUT_ANALOG);
         temperatures[i] = 0.0f;
+    }
+    for (uint8_t i = 0; i < NUM_FANS; ++i) {
+        fanSpeeds[i] = 0;
+        rgbDriver.setChannelPWM(fanMap[i].pwmChannel, 0);
     }
 }
 
 void TempSensors::update() {
-    for (uint8_t i = 0; i < 4; ++i) {
+    for (uint8_t i = 0; i < NUM_SENSORS; ++i) {
         uint16_t raw = analogRead(sensorPins[i]);
         float temperature = (raw * 330.0f) / 4095.0f; // LM35: 10mV per degC, 3.3V ref
         temperatures[i] = temperature;
     }
+
+    for (uint8_t i = 0; i < NUM_FANS; ++i) {
+        const FanMapping &m = fanMap[i];
+        float t = temperatures[m.sensorIndex];
+        float factor;
+        if (t <= m.nominalTemp) {
+            factor = 0.0f;
+        } else if (t >= m.maxTemp) {
+            factor = 1.0f;
+        } else {
+            factor = (t - m.nominalTemp) / (m.maxTemp - m.nominalTemp);
+        }
+        uint16_t pwm = static_cast<uint16_t>(factor * 4095.0f);
+        setFanSpeed(i, pwm);
+    }
 }
 
 float TempSensors::getTemperatureC(uint8_t index) const {
-    if (index >= 4) return NAN;
+    if (index >= NUM_SENSORS) return NAN;
     return temperatures[index];
+}
+
+void TempSensors::setFanSpeed(uint8_t index, uint16_t pwm) {
+    if (index >= NUM_FANS) return;
+    if (pwm > 4095) pwm = 4095;
+    fanSpeeds[index] = pwm;
+    rgbDriver.setChannelPWM(fanMap[index].pwmChannel, pwm);
 }
 

--- a/Ground Control Station/BottomPanelCode/lib/TempSensors/TempSensors.h
+++ b/Ground Control Station/BottomPanelCode/lib/TempSensors/TempSensors.h
@@ -2,15 +2,31 @@
 
 #include <Arduino.h>
 #include <pins.h>
+#include <leds.h>
 
 class TempSensors {
 public:
     void begin();               // setup ADC pins
-    void update();              // read all sensors
+    void update();              // read all sensors and adjust fans
     float getTemperatureC(uint8_t index) const;  // get last temperature for sensor 0..3
 
 private:
-    static const uint8_t sensorPins[4];
-    float temperatures[4];
+    struct FanMapping {
+        uint8_t pwmChannel;    // PCA9685 channel
+        uint8_t sensorIndex;   // linked temperature sensor
+        float nominalTemp;     // °C where fan starts increasing
+        float maxTemp;         // °C for full speed
+    };
+
+    static constexpr uint8_t NUM_SENSORS = 4;
+    static constexpr uint8_t NUM_FANS = 2;
+
+    static const uint8_t sensorPins[NUM_SENSORS];
+    static const FanMapping fanMap[NUM_FANS];
+
+    uint16_t fanSpeeds[NUM_FANS];
+    float temperatures[NUM_SENSORS];
+
+    void setFanSpeed(uint8_t index, uint16_t pwm);
 };
 

--- a/Ground Control Station/BottomPanelCode/lib/pins/pins.h
+++ b/Ground Control Station/BottomPanelCode/lib/pins/pins.h
@@ -85,6 +85,10 @@ constexpr uint8_t PIN_SENS3 = PB1;
 constexpr uint8_t PIN_SENS4  = PA6;
 constexpr uint8_t PIN_SENS5  = PA7;
 
+// ----------- Fan PWM channels on PCA9685 -----------
+constexpr uint8_t FAN1_PWM_CH = 6;  // shares PCA9685 with analog RGB LEDs
+constexpr uint8_t FAN2_PWM_CH = 7;
+
 extern SPIClass SPI_2;
 extern Adafruit_MCP23X17 IoExp;
 


### PR DESCRIPTION
## Summary
- map two PCA9685 channels for fans in `pins.h`
- extend `TempSensors` with configurable fan mappings
- control fan speeds in `update()` based on sensor temps

## Testing
- `pio run -e blackpill_f411ce`


------
https://chatgpt.com/codex/tasks/task_e_6873c94bfaac833290c31cd10ede032b