### PR TITLE
Fix debug macros

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/Switches/Switches.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/Switches/Switches.cpp
@@ -110,10 +110,14 @@ namespace Switches {
         #endif  // DEBUG_SCREENTEST
 
         SwitchHandler::addSwitch(PINIO_KEY, [](bool state) {
-              // Set PC13 high when key is pressed
-            if(state) {
+#ifdef DEBUG_SCREENTEST
+            bool pressed = !state; // PA0 uses pull-up, LOW means pressed
+#else
+            bool pressed = state;
+#endif
+            if(pressed) {
                 digitalWrite(PC13, HIGH);
-                // Key is HIGH - unlock the case
+                // Key is HIGH/pressed - unlock the case
                 isLocked = false;
                 // Check if all switches are in low position to confirm safe operation
                 if(allSwitchesLow()) {
@@ -122,7 +126,7 @@ namespace Switches {
                     isConfirmed = false; // Switches not safe, keep functionality disabled
                 }
             } else {
-                // Key is LOW - lock the case immediately
+                // Key is LOW/unpressed - lock the case immediately
                 digitalWrite(PC13, LOW);
                 isLocked = true;
                 isConfirmed = false;  // Reset confirmation when locking
@@ -140,7 +144,7 @@ namespace Switches {
     bool allSwitchesLow() {
         #ifdef DEBUG_SCREENTEST
         // Debug mode: Check PA0
-        return digitalRead(PA0);  // Return true if switch is LOW (not pressed)
+        return !digitalRead(PA0);  // Return true if switch is LOW (not pressed)
         #else
         // Normal mode: Check all switches via IoExp
         bool allLow = true;

--- a/Ground Control Station/BottomPanelCode/src/main.cpp
+++ b/Ground Control Station/BottomPanelCode/src/main.cpp
@@ -13,25 +13,29 @@ void setup() {
   USB_Begin();  // Wrapper rond USBD_Init() + connect
   BootKeyboard.begin();  // Init HID class
   setupPins();
-  // powerDisplay.begin();
+  powerDisplay.begin();
   Switches::begin();
-  // tempSensors.begin();  // Initialize temperature sensors
+  tempSensors.begin();  // Initialize temperature sensors
 }
 
 void loop() {
   Switches::update();  // Check all switches for state changes
-  // tempSensors.update();  // Update temperature sensors and adjust fans
-  // // Show appropriate screen based on lock state and confirmation
-  // if(Switches::isLocked) {
-  //   powerDisplay.showLockScreen();  // Show lock icon when locked
-  // } else {
-  //   // Case is unlocked - check if switches were confirmed during unlock
-  //   if(!Switches::isConfirmed) {
-  //     powerDisplay.showWarningScreen();  // Show warning when switches were not confirmed safe during unlock
-  //   } else {
-  //     powerDisplay.showMainScreen();  // Show normal screen when switches were confirmed safe
-  //   }
-  // }
+
+  #ifdef DEBUG_LED
+  powerDisplay.showBatWarningScreen();  // Show lock screen in debug mode
+  #else
+  // Show appropriate screen based on lock state and confirmation
+  if(Switches::isLocked) {
+    powerDisplay.showLockScreen();  // Show lock icon when locked
+  } else {
+    // Case is unlocked - check if switches were confirmed during unlock
+    if(!Switches::isConfirmed) {
+      powerDisplay.showWarningScreen();  // Show warning when switches were not confirmed safe during unlock
+    } else {
+      powerDisplay.showMainScreen();  // Show normal screen when switches were confirmed safe
+    }
+  }
+  #endif
 #ifdef DEBUG_LED
   startup();
 #endif


### PR DESCRIPTION
## Summary
- restore `powerDisplay.begin()` and `tempSensors.begin()`
- show debug screens again and fix `allSwitchesLow()` for screen debug
- fix the debug key logic to unlock correctly when pressed

## Testing
- `platformio run -e DEBUGSCREENTEST`
- `platformio run -e PRODUCTION`
- `platformio run -e DEBUGLED`

------
https://chatgpt.com/codex/tasks/task_e_6873f697ba788332aa3bed383d0daea3