### PR TITLE
Fix DEBUG_SCREENTEST input handling

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/SwitchHandler/SwitchHandler.cpp
@@ -6,22 +6,22 @@
 Switch::Switch(int pin, Callback cb)
     : pin(pin), callback(cb)
 {
-    #ifdef DEBUG_HID
-        // Debug mode: Use standard GPIO pins instead of IoExp
+    #if defined(DEBUG_HID) || defined(DEBUG_SCREENTEST)
+        // Debug/Screen test modes: read from MCU pin instead of IO expander
         lastState = digitalRead(pin);
     #else
-        // Normal mode: Use IoExp
+        // Normal mode: read from IO expander
         lastState = IoExp.digitalRead(pin);
     #endif
 
 }
 
 void Switch::update() {
-    #ifdef DEBUG_HID
-        // Debug mode: Use standard GPIO pins
+    #if defined(DEBUG_HID) || defined(DEBUG_SCREENTEST)
+        // Debug/Screen test modes: read from MCU pin
         bool currentState = digitalRead(pin);
     #else
-        // Normal mode: Use IoExp
+        // Normal mode: read from IO expander
         bool currentState = IoExp.digitalRead(pin);
     #endif
     if (currentState != lastState) {


### PR DESCRIPTION
## Summary
- switch handler should read key pin from MCU when using DEBUG_SCREENTEST

## Testing
- `pio run -e DEBUGSCREENTEST` *(fails: took too long to finish in container)*

------
https://chatgpt.com/codex/tasks/task_e_6873fe89b3b08332aaeea88673313ebb