### PR TITLE
Integrate RTOS blinking tasks

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
@@ -1,45 +1,48 @@
 #include "Blinker.h"
 #include "pins.h"
 
-// Basic non-blocking blinker implementation.
+// FreeRTOS powered non-blocking blinker implementation.
 
-// Constructor stores the pin number and blink interval.
 Blinker::Blinker(uint8_t pin, unsigned long interval)
-  : _pin(pin), _interval(interval), _lastToggle(0), _state(LOW), _active(false) {}
+    : _pin(pin), _interval(interval), _taskHandle(nullptr),
+      _state(LOW), _active(false) {}
 
-// Configure the pin and set the starting state.
 void Blinker::begin(bool startState) {
-  _state = startState;
-  IoExp.digitalWrite(_pin, _state);
-  _lastToggle = millis();
-  _active = true;
-}
-
-// Toggle the pin when enough time has passed.
-void Blinker::update() {
-  if (!_active) return;
-
-  unsigned long now = millis();
-  if (now - _lastToggle >= _interval) {
-    _state = !_state;
+    _state = startState;
     IoExp.digitalWrite(_pin, _state);
-    _lastToggle = now;
-  }
+    _active = true;
+
+    if (_taskHandle == nullptr) {
+        xTaskCreate(taskFunc, "BLNK", 128, this, 1, &_taskHandle);
+    }
 }
 
-// Change how fast the LED blinks.
+void Blinker::update() {
+    // Handled by the FreeRTOS task
+}
+
 void Blinker::setInterval(unsigned long interval) {
-  _interval = interval;
+    _interval = interval;
 }
 
-// Stop blinking and turn the LED off.
 void Blinker::stop() {
-  _active = false;
-  IoExp.digitalWrite(_pin, LOW);
+    _active = false;
+    IoExp.digitalWrite(_pin, LOW);
 }
 
-// Resume blinking from the current time.
 void Blinker::start() {
-  _lastToggle = millis();
-  _active = true;
+    _active = true;
+}
+
+void Blinker::taskFunc(void *arg) {
+    Blinker *self = static_cast<Blinker *>(arg);
+    for (;;) {
+        if (self->_active) {
+            self->_state = !self->_state;
+            IoExp.digitalWrite(self->_pin, self->_state);
+            vTaskDelay(pdMS_TO_TICKS(self->_interval));
+        } else {
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+    }
 }

--- a/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
@@ -28,6 +28,11 @@ void Blinker::setInterval(unsigned long interval) {
 void Blinker::stop() {
     _active = false;
     IoExp.digitalWrite(_pin, LOW);
+
+    if (_taskHandle != nullptr) {
+        vTaskDelete(_taskHandle);
+        _taskHandle = nullptr;
+    }
 }
 
 void Blinker::start() {

--- a/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.h
+++ b/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.h
@@ -4,16 +4,19 @@
 // Small utility class to blink a GPIO pin at a configurable interval.
 
 #include <Arduino.h>
+#include <STM32FreeRTOS.h>
 
 class Blinker {
 public:
   // Create a new blinker on the given GPIO pin.
   Blinker(uint8_t pin, unsigned long interval);
 
-  // Prepare the pin and optionally set the initial state.
+  // Prepare the pin and start the FreeRTOS task. Optionally set the
+  // initial output state.
   void begin(bool startState = LOW);
 
-  // Toggle the pin when the interval elapsed.
+  // Legacy update method kept for compatibility. No longer needed as the
+  // blinking is handled inside the FreeRTOS task.
   void update();
 
   // Change the blinking interval.
@@ -28,9 +31,11 @@ public:
 private:
   uint8_t _pin;
   unsigned long _interval;
-  unsigned long _lastToggle;
+  TaskHandle_t _taskHandle;
   bool _state;
   bool _active;
+
+  static void taskFunc(void *arg);
 };
 
 #endif

--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
@@ -1,5 +1,6 @@
 #include "ScreenPowerSwitch.h"
 #include "bitmaps.h"
+#include <STM32FreeRTOS.h>
 
 // Implementation of the ScreenPowerSwitch class which renders
 // various screens on the TFT and animates the selector arm.
@@ -94,7 +95,7 @@ void ScreenPowerSwitch::animateSwitch(PowerSource from, PowerSource to) {
         float t = i / (float)steps;
         float angle = startAngle + (endAngle - startAngle) * t;
         drawSwitchArm(angle, ST77XX_YELLOW, true);
-        delay(40);
+        vTaskDelay(pdMS_TO_TICKS(40));
     }
 
     currentPower = to;

--- a/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
@@ -131,7 +131,7 @@ void setLed(int switchId, rgbwValue color, bool blinking){
 
 // Update blinking LEDs (called from a FreeRTOS task)
 void updateLeds() {
-    unsigned long currentTime = xTaskGetTickCount();
+    TickType_t currentTime = xTaskGetTickCount();
     bool stripNeedsUpdate = false;
     
     for (int i = 0; i < numSwitches; i++) {

--- a/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
@@ -1,6 +1,7 @@
 #include "leds.h"
 #include "pins.h"
 #include "Blinker.h"
+#include <STM32FreeRTOS.h>
 
 // Implementation for LED effects and helper routines.
 
@@ -43,7 +44,7 @@ Blinker* blinkers[numSwitches] = {
 // Blinking state for strip LEDs and PWM LEDs
 bool stripBlinking[numSwitches] = {false};
 rgbwValue stripBlinkColor[numSwitches] = {{0}};
-unsigned long lastBlinkTime[numSwitches] = {0};
+TickType_t lastBlinkTime[numSwitches] = {0};
 bool blinkState[numSwitches] = {false};
 
 // Initialise the NeoPixel strip and PCA9685 driver.
@@ -64,7 +65,7 @@ void setupLeds(){
         }
         stripBlinking[i] = false;
         stripBlinkColor[i] = {0, 0, 0, 0};
-        lastBlinkTime[i] = 0;
+        lastBlinkTime[i] = xTaskGetTickCount();
         blinkState[i] = false;
     }
 }
@@ -128,15 +129,15 @@ void setLed(int switchId, rgbwValue color, bool blinking){
     }
 }
 
-// Update blinking LEDs (call this regularly in main loop)
+// Update blinking LEDs (called from a FreeRTOS task)
 void updateLeds() {
-    unsigned long currentTime = millis();
+    unsigned long currentTime = xTaskGetTickCount();
     bool stripNeedsUpdate = false;
     
     for (int i = 0; i < numSwitches; i++) {
         if (stripBlinking[i]) {
             // Check if it's time to toggle (500ms interval)
-            if (currentTime - lastBlinkTime[i] >= 500) {
+            if (currentTime - lastBlinkTime[i] >= pdMS_TO_TICKS(500)) {
                 blinkState[i] = !blinkState[i];
                 lastBlinkTime[i] = currentTime;
                 
@@ -182,13 +183,6 @@ void updateLeds() {
                     stripNeedsUpdate = true;
                 }
             }
-        }
-    }
-    
-    // Update GPIO blinkers
-    for (int i = 0; i < numSwitches; i++) {
-        if (blinkers[i] != nullptr) {
-            blinkers[i]->update();
         }
     }
     
@@ -242,7 +236,7 @@ bool startup() {
             }
         }
 
-        delay(interval);  // korte pauze voor de animatie
+        vTaskDelay(pdMS_TO_TICKS(interval));  // korte pauze voor de animatie
     }
 
     // Alles uitzetten na animatie

--- a/Ground Control Station/BottomPanelCode/src/main.cpp
+++ b/Ground Control Station/BottomPanelCode/src/main.cpp
@@ -30,6 +30,7 @@ BootKeyboard.begin();  // Init HID class
 
   xTaskCreate(uiTask, "UI", 512, nullptr, 2, nullptr);
   xTaskCreate(tempTask, "TEMP", 512, nullptr, 1, nullptr);
+  xTaskCreate(blinkTask, "LED", 256, nullptr, 1, nullptr);
 
   vTaskStartScheduler();
 }
@@ -72,6 +73,14 @@ static void tempTask(void *) {
   for (;;) {
     tempSensors.update();
     vTaskDelay(pdMS_TO_TICKS(100));
+  }
+}
+
+// Dedicated LED update task
+static void blinkTask(void *) {
+  for (;;) {
+    updateLeds();
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 }
 


### PR DESCRIPTION
## Summary
- run LED blinker with FreeRTOS task
- use RTOS delays and tick counts for LED and screen functions
- create periodic LED task in main firmware

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_688bc9c0176c8332a38ec188afaac988