### PR TITLE
Use FreeRTOS for LED handling

### DIFF
--- a/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.cpp
@@ -1,30 +1,24 @@
 #include "Blinker.h"
 #include "pins.h"
+#include <STM32FreeRTOS.h>
 
-// Basic non-blocking blinker implementation.
+// Implementation of the Blinker class using a FreeRTOS task.
 
 // Constructor stores the pin number and blink interval.
 Blinker::Blinker(uint8_t pin, unsigned long interval)
-  : _pin(pin), _interval(interval), _lastToggle(0), _state(LOW), _active(false) {}
+  : _pin(pin), _interval(interval), _state(LOW), _active(false), _taskHandle(nullptr) {}
 
 // Configure the pin and set the starting state.
 void Blinker::begin(bool startState) {
   _state = startState;
   IoExp.digitalWrite(_pin, _state);
-  _lastToggle = millis();
   _active = true;
+  xTaskCreate(taskTrampoline, "Blink", 128, this, 1, &_taskHandle);
 }
 
 // Toggle the pin when enough time has passed.
 void Blinker::update() {
-  if (!_active) return;
-
-  unsigned long now = millis();
-  if (now - _lastToggle >= _interval) {
-    _state = !_state;
-    IoExp.digitalWrite(_pin, _state);
-    _lastToggle = now;
-  }
+  // handled by FreeRTOS task
 }
 
 // Change how fast the LED blinks.
@@ -40,6 +34,18 @@ void Blinker::stop() {
 
 // Resume blinking from the current time.
 void Blinker::start() {
-  _lastToggle = millis();
   _active = true;
+}
+
+void Blinker::taskTrampoline(void *pv) {
+  Blinker *b = static_cast<Blinker *>(pv);
+  for (;;) {
+    if (b->_active) {
+      b->_state = !b->_state;
+      IoExp.digitalWrite(b->_pin, b->_state);
+      vTaskDelay(pdMS_TO_TICKS(b->_interval));
+    } else {
+      vTaskDelay(pdMS_TO_TICKS(10));
+    }
+  }
 }

--- a/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.h
+++ b/Ground Control Station/BottomPanelCode/lib/Blinker/Blinker.h
@@ -1,9 +1,10 @@
 #ifndef BLINKER_H
 #define BLINKER_H
 
-// Small utility class to blink a GPIO pin at a configurable interval.
+// Small utility class to blink a GPIO pin using a dedicated FreeRTOS task.
 
 #include <Arduino.h>
+#include <STM32FreeRTOS.h>
 
 class Blinker {
 public:
@@ -13,7 +14,7 @@ public:
   // Prepare the pin and optionally set the initial state.
   void begin(bool startState = LOW);
 
-  // Toggle the pin when the interval elapsed.
+  // (Legacy) manual update, kept for compatibility. No-op when using FreeRTOS.
   void update();
 
   // Change the blinking interval.
@@ -28,9 +29,12 @@ public:
 private:
   uint8_t _pin;
   unsigned long _interval;
-  unsigned long _lastToggle;
   bool _state;
   bool _active;
+  TaskHandle_t _taskHandle;
+
+  static void taskTrampoline(void *);
 };
 
 #endif
+

--- a/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/ScreenPowerSwitch/ScreenPowerSwitch.cpp
@@ -1,5 +1,6 @@
 #include "ScreenPowerSwitch.h"
 #include "bitmaps.h"
+#include <STM32FreeRTOS.h>
 
 // Implementation of the ScreenPowerSwitch class which renders
 // various screens on the TFT and animates the selector arm.
@@ -94,7 +95,7 @@ void ScreenPowerSwitch::animateSwitch(PowerSource from, PowerSource to) {
         float t = i / (float)steps;
         float angle = startAngle + (endAngle - startAngle) * t;
         drawSwitchArm(angle, ST77XX_YELLOW, true);
-        delay(40);
+        vTaskDelay(pdMS_TO_TICKS(40));
     }
 
     currentPower = to;

--- a/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
+++ b/Ground Control Station/BottomPanelCode/lib/leds/leds.cpp
@@ -1,6 +1,7 @@
 #include "leds.h"
 #include "pins.h"
 #include "Blinker.h"
+#include <STM32FreeRTOS.h>
 
 // Implementation for LED effects and helper routines.
 
@@ -185,13 +186,6 @@ void updateLeds() {
         }
     }
     
-    // Update GPIO blinkers
-    for (int i = 0; i < numSwitches; i++) {
-        if (blinkers[i] != nullptr) {
-            blinkers[i]->update();
-        }
-    }
-    
     // Update strip if any strip LED changed
     if (stripNeedsUpdate) {
         strip.show();
@@ -242,7 +236,7 @@ bool startup() {
             }
         }
 
-        delay(interval);  // korte pauze voor de animatie
+        vTaskDelay(pdMS_TO_TICKS(interval));  // korte pauze via RTOS
     }
 
     // Alles uitzetten na animatie

--- a/Ground Control Station/BottomPanelCode/lib/leds/leds.h
+++ b/Ground Control Station/BottomPanelCode/lib/leds/leds.h
@@ -48,7 +48,7 @@ extern const SwitchLedMapping switchMap[numSwitches];
 void setupLeds();
 // Set the colour for a particular switch LED.
 void setLed(int switchId, rgbwValue color, bool blinking = false);
-// Update blinking LEDs (call this regularly in main loop)
+// Update blinking LEDs (called from RTOS task)
 void updateLeds();
 // Startup animation played once at boot.
 bool startup();

--- a/Ground Control Station/BottomPanelCode/src/main.cpp
+++ b/Ground Control Station/BottomPanelCode/src/main.cpp
@@ -8,14 +8,15 @@
 #include <ScreenPowerSwitch.h>
 #include <TempSensors.h>
 #include <STM32FreeRTOS.h>
+#include <leds.h>
 
 
 ScreenPowerSwitch powerDisplay;
 TempSensors tempSensors;
 
 static void uiTask(void *);
-static void tempTask(void *);
-static void blinkTask(void *);
+static void tempTask(void *); 
+static void blinkTask(void *); 
 
 // Set up peripherals, create tasks and start the scheduler.
 void setup() {
@@ -30,6 +31,7 @@ BootKeyboard.begin();  // Init HID class
 
   xTaskCreate(uiTask, "UI", 512, nullptr, 2, nullptr);
   xTaskCreate(tempTask, "TEMP", 512, nullptr, 1, nullptr);
+  xTaskCreate(blinkTask, "LED", 256, nullptr, 1, nullptr);
 
   vTaskStartScheduler();
 }
@@ -72,6 +74,15 @@ static void tempTask(void *) {
   for (;;) {
     tempSensors.update();
     vTaskDelay(pdMS_TO_TICKS(100));
+  }
+}
+
+// LED update task: blinks the onboard LED and services LED animations
+static void blinkTask(void *) {
+  for (;;) {
+    digitalWrite(PC13, !digitalRead(PC13));
+    updateLeds();
+    vTaskDelay(pdMS_TO_TICKS(50));
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor Blinker class to use its own FreeRTOS task
- delay LED effects through `vTaskDelay`
- run LED update task alongside existing tasks
- add RTOS includes and clarify documentation

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_688bc9c0176c8332a38ec188afaac988