### PR TITLE
Add Qt6 ground control station application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Docs/Facturen
 Ground Control Station/BottomPanelCode/.idea/encodings.xml
 /Ground Control Station/BottomPanelCode/.idea
+build/

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(GroundControlStation LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets SerialPort)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(HIDAPI REQUIRED hidapi-hidraw)
+
+add_executable(gcs
+    src/main.cpp
+    src/MainWindow.cpp
+    src/SerialHandler.cpp
+    src/HIDHandler.cpp
+)
+
+target_include_directories(gcs PRIVATE src ${HIDAPI_INCLUDE_DIRS})
+target_link_libraries(gcs PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets Qt6::SerialPort ${HIDAPI_LIBRARIES})

--- a/application/README.md
+++ b/application/README.md
@@ -1,0 +1,20 @@
+# Ground Control Station Application
+
+This is a minimal ground control station (GCS) example built with **Qt 6**. It demonstrates how to
+integrate different subsystems such as serial communication and HID devices in a cross‑platform GUI.
+
+## Features
+
+* **Serial Port** – Uses `QSerialPort` to send/receive data from flight hardware.
+* **HID** – Uses `hidapi` to read generic USB HID devices such as gamepads.
+* **Qt Widgets UI** – Basic `QMainWindow` with log output.
+
+## Build Instructions
+
+```bash
+cmake -S application -B build
+cmake --build build
+./build/gcs
+```
+
+Make sure `qt6-base-dev`, `qt6-serialport-dev`, and `libhidapi-dev` are installed.

--- a/application/src/HIDHandler.cpp
+++ b/application/src/HIDHandler.cpp
@@ -1,0 +1,33 @@
+#include "HIDHandler.h"
+
+HIDHandler::HIDHandler(QObject *parent) : QObject(parent) {
+    hid_init();
+    connect(&timer, &QTimer::timeout, this, &HIDHandler::poll);
+}
+
+HIDHandler::~HIDHandler() {
+    if (device)
+        hid_close(device);
+    hid_exit();
+}
+
+bool HIDHandler::openFirst() {
+    hid_device_info *info = hid_enumerate(0x0, 0x0);
+    if (!info)
+        return false;
+    device = hid_open_path(info->path);
+    hid_free_enumeration(info);
+    if (!device)
+        return false;
+    timer.start(100);
+    return true;
+}
+
+void HIDHandler::poll() {
+    if (!device)
+        return;
+    unsigned char buf[64];
+    int res = hid_read(device, buf, sizeof(buf));
+    if (res > 0)
+        emit report(QByteArray(reinterpret_cast<char *>(buf), res));
+}

--- a/application/src/HIDHandler.h
+++ b/application/src/HIDHandler.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <QObject>
+#include <hidapi/hidapi.h>
+#include <QTimer>
+
+class HIDHandler : public QObject {
+    Q_OBJECT
+public:
+    explicit HIDHandler(QObject *parent = nullptr);
+    ~HIDHandler();
+    bool openFirst();
+signals:
+    void report(const QByteArray &data);
+private slots:
+    void poll();
+private:
+    hid_device *device = nullptr;
+    QTimer timer;
+};

--- a/application/src/MainWindow.cpp
+++ b/application/src/MainWindow.cpp
@@ -1,0 +1,23 @@
+#include "MainWindow.h"
+#include <QVBoxLayout>
+#include <QWidget>
+
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
+    log = new QTextEdit(this);
+    log->setReadOnly(true);
+    QWidget *central = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(central);
+    layout->addWidget(log);
+    setCentralWidget(central);
+
+    connect(&serial, &SerialHandler::received, this, [this](const QByteArray &data){
+        log->append(QString::fromUtf8("Serial: ") + QString::fromUtf8(data));
+    });
+
+    connect(&hid, &HIDHandler::report, this, [this](const QByteArray &data){
+        log->append(QString::fromUtf8("HID: ") + data.toHex(' '));
+    });
+
+    serial.open(QStringLiteral("/dev/ttyUSB0"));
+    hid.openFirst();
+}

--- a/application/src/MainWindow.h
+++ b/application/src/MainWindow.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <QMainWindow>
+#include <QTextEdit>
+#include "SerialHandler.h"
+#include "HIDHandler.h"
+
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+private:
+    QTextEdit *log;
+    SerialHandler serial;
+    HIDHandler hid;
+};

--- a/application/src/SerialHandler.cpp
+++ b/application/src/SerialHandler.cpp
@@ -1,0 +1,16 @@
+#include "SerialHandler.h"
+
+SerialHandler::SerialHandler(QObject *parent) : QObject(parent) {
+    connect(&serial, &QSerialPort::readyRead, this, &SerialHandler::handleReadyRead);
+}
+
+void SerialHandler::open(const QString &portName, int baudRate) {
+    serial.setPortName(portName);
+    serial.setBaudRate(baudRate);
+    serial.open(QIODevice::ReadWrite);
+}
+
+void SerialHandler::handleReadyRead() {
+    QByteArray data = serial.readAll();
+    emit received(data);
+}

--- a/application/src/SerialHandler.h
+++ b/application/src/SerialHandler.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <QObject>
+#include <QSerialPort>
+
+class SerialHandler : public QObject {
+    Q_OBJECT
+public:
+    explicit SerialHandler(QObject *parent = nullptr);
+    void open(const QString &portName, int baudRate = 115200);
+signals:
+    void received(const QByteArray &data);
+private slots:
+    void handleReadyRead();
+private:
+    QSerialPort serial;
+};

--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -1,0 +1,9 @@
+#include <QApplication>
+#include "MainWindow.h"
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- Add Qt6-based ground control station example application
- Integrate serial port and HID device handling
- Provide build instructions and ignore build output

## Testing
- `cmake -S application -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68bd92ef41c88332a22d1f9b9712998d