### PR TITLE
Ensure App builds against Qt6 and add basic GCS UI

### DIFF
--- a/Ground Control Station/App/CMakeLists.txt
+++ b/Ground Control Station/App/CMakeLists.txt
@@ -9,62 +9,23 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+# This application is intended to build against Qt6 exclusively.
+# Using find_package with Qt5 fallback can accidentally select an older
+# Qt version, so we explicitly require Qt6 here.
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 set(PROJECT_SOURCES
-        main.cpp
-        mainwindow.cpp
-        mainwindow.h
-        mainwindow.ui
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+    mainwindow.ui
 )
 
-if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
-    qt_add_executable(App
-        MANUAL_FINALIZATION
-        ${PROJECT_SOURCES}
-    )
-# Define target properties for Android with Qt 6 as:
-#    set_property(TARGET App APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
-#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
-# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
-else()
-    if(ANDROID)
-        add_library(App SHARED
-            ${PROJECT_SOURCES}
-        )
-# Define properties for Android with Qt 5 after find_package() calls as:
-#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
-    else()
-        add_executable(App
-            ${PROJECT_SOURCES}
-        )
-    endif()
-endif()
-
-target_link_libraries(App PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-
-# Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
-# If you are developing for iOS or macOS you should consider setting an
-# explicit, fixed bundle identifier manually though.
-if(${QT_VERSION} VERSION_LESS 6.1.0)
-  set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.example.App)
-endif()
-set_target_properties(App PROPERTIES
-    ${BUNDLE_ID_OPTION}
-    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    MACOSX_BUNDLE TRUE
-    WIN32_EXECUTABLE TRUE
+qt_add_executable(App
+    MANUAL_FINALIZATION
+    ${PROJECT_SOURCES}
 )
 
-include(GNUInstallDirs)
-install(TARGETS App
-    BUNDLE DESTINATION .
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+target_link_libraries(App PRIVATE Qt6::Widgets)
 
-if(QT_VERSION_MAJOR EQUAL 6)
-    qt_finalize_executable(App)
-endif()
+qt_finalize_executable(App)

--- a/Ground Control Station/App/mainwindow.cpp
+++ b/Ground Control Station/App/mainwindow.cpp
@@ -1,5 +1,5 @@
 #include "mainwindow.h"
-#include "./ui_mainwindow.h"
+#include "ui_mainwindow.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -11,4 +11,14 @@ MainWindow::MainWindow(QWidget *parent)
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::on_connectButton_clicked()
+{
+    ui->statusLabel->setText("Connected");
+}
+
+void MainWindow::on_disconnectButton_clicked()
+{
+    ui->statusLabel->setText("Disconnected");
 }

--- a/Ground Control Station/App/mainwindow.h
+++ b/Ground Control Station/App/mainwindow.h
@@ -17,6 +17,10 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+private slots:
+    void on_connectButton_clicked();
+    void on_disconnectButton_clicked();
+
 private:
     Ui::MainWindow *ui;
 };

--- a/Ground Control Station/App/mainwindow.ui
+++ b/Ground Control Station/App/mainwindow.ui
@@ -11,9 +11,93 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>KL-UAS GCS</string>
   </property>
-  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QGroupBox" name="mapGroup">
+      <property name="title">
+       <string>Map</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QGraphicsView" name="mapView"/>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <layout class="QVBoxLayout" name="rightLayout">
+      <item>
+       <widget class="QGroupBox" name="connectionGroup">
+        <property name="title">
+         <string>Connection</string>
+        </property>
+        <layout class="QHBoxLayout" name="connectionLayout">
+         <item>
+          <widget class="QLabel" name="statusLabel">
+           <property name="text">
+            <string>Disconnected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="connectButton">
+           <property name="text">
+            <string>Connect</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="disconnectButton">
+           <property name="text">
+            <string>Disconnect</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="telemetryGroup">
+        <property name="title">
+         <string>Telemetry</string>
+        </property>
+        <layout class="QVBoxLayout" name="telemetryLayout">
+         <item>
+          <widget class="QPlainTextEdit" name="telemetryView"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="controlsGroup">
+        <property name="title">
+         <string>Controls</string>
+        </property>
+        <layout class="QHBoxLayout" name="controlsLayout">
+         <item>
+          <widget class="QPushButton" name="takeoffButton">
+           <property name="text">
+            <string>Takeoff</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="landButton">
+           <property name="text">
+            <string>Land</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
## Summary
- require Qt6 in App CMake configuration and simplify target setup
- add a starter ground control station interface with map, telemetry log, and flight controls
- wire connection buttons to update status display

## Testing
- `cmake -S "Ground Control Station/App" -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68bd98c3f44883329cdcf9e5014aa662