### PR TITLE
Add multi-MCU RS-485 peripheral slave framework

### DIFF
--- a/Peripherals/Docs/RS485_PERIPHERAL_BUS.md
+++ b/Peripherals/Docs/RS485_PERIPHERAL_BUS.md
@@ -1,0 +1,746 @@
+# RS-485 Peripheral Bus — GCS Extension Interface
+
+This document describes the RS-485 based peripheral bus exposed on the 8-pin rear connector of the GCS flight case. It covers the physical layer, required components, protocol, and example peripheral designs.
+
+---
+
+## Overview
+
+Each peripheral on the bus is an independent MCU-based module. The GCS Pico acts as **bus master**; peripherals are **slaves** that respond only when addressed. The bus uses RS-485 differential signalling, making it robust against EMI, ground noise, and long cable runs — all common in field UAS operations.
+
+```
+GCS Pico (UART1)
+    │
+    GP8 (TX) ──► MAX485 DI
+    GP9 (RX) ◄── MAX485 RO
+    GP2 (DE/RE)─► MAX485 DE + /RE
+    │
+    MAX485 A/B ══════════════════════════════════ 8-pin rear connector
+                                                        │
+                              ┌─────────────────────────┤
+                              │                         │
+                         Peripheral A             Peripheral B
+                         (Searchlight)            (Radar node)
+                         MAX485 + MCU             MAX485 + MCU
+                         addr = 0x01              addr = 0x02
+```
+
+---
+
+## Physical Layer
+
+### Bus characteristics
+
+| Parameter | Value |
+|---|---|
+| Signalling | RS-485 half-duplex differential |
+| Max nodes | 32 (standard) — more with repeater |
+| Max cable length | ~1200 m at 9600 baud / ~100 m at 460800 baud |
+| Recommended baud rate | 115200 baud (field default) |
+| Logic levels | Differential: A−B > +200 mV = mark, A−B < −200 mV = space |
+| Termination | 120 Ω across A/B at each **end** of the bus |
+| Cable type | Shielded twisted pair (STP), e.g. Belden 9841 or CAT5 |
+
+### 8-pin rear connector pinout
+
+Recommended connector: **GX16-8** circular aviation connector (IP54, field-proven, locking).
+
+| Pin | Signal | Notes |
+| ----- | -------- | ------- |
+| 1 | GND | Common ground — connect shield here too |
+| 2 | +5 V | Regulated 5 V for peripheral logic / MCU |
+| 3 | RS-485 A | Differential data line + |
+| 4 | spare | Reserved for future expansion |
+| 5 | spare | Reserved for future expansion |
+| 6 | /INT | Open-drain alert — peripheral pulls low to signal async event |
+| 7 | RS-485 B | Differential data line − |
+| 8 | VIN | Fused raw battery voltage for high-power loads |
+
+> **Cable colour suggestion (for consistent field builds):**
+> GND = Brown, +5 V = Red, VIN = White, A = Green, B = Blue, /INT = Orange.
+
+---
+
+## GCS-Side Hardware
+
+### Components
+
+| Component | Part | Package | Purpose |
+|---|---|---|---|
+| RS-485 transceiver | **SP3485EN** (3.3 V) | SOIC-8 | Converts UART1 to RS-485 differential |
+| Bus termination | 120 Ω 0402, 1% | — | Across A/B at the PCB-side bus end |
+| ESD / surge protection | **PRTR5V0U2X** or 2× **SMBJ6.5A** TVS | SOT-363 / SMB | On A and B before the connector |
+| VBAT fuse | Polyfuse 1 A (e.g. MF-MSMF110) | 1812 | Inline with VBAT connector pin |
+| Pull-up / pull-down | 560 Ω to 3.3 V on A, 560 Ω to GND on B | 0402 | Bias bus to idle mark when no driver active |
+
+### SP3485 wiring (SOIC-8)
+
+```
+Pico GP8 (UART1 TX) ──── SP3485 pin 4 (DI)
+Pico GP9 (UART1 RX) ──── SP3485 pin 1 (RO)
+Pico GP2            ──┬─ SP3485 pin 3 (DE)   ← drive high to transmit
+                      └─ SP3485 pin 2 (/RE)  ← tie to DE (both together)
+Pico GP6 (/INT in)  ──── 8-pin connector pin 6 + 10 kΩ pull-up to 3.3 V
+                         (open-drain; peripherals pull low to signal event)
+
+SP3485 pin 6 (A) ──── bus A (via TVS)
+SP3485 pin 7 (B) ──── bus B (via TVS)
+
+SP3485 pin 8 (VCC) ── 3.3 V + 100 nF to GND
+SP3485 pin 5 (GND) ── GND
+```
+
+> Use SP3485 (3.3 V) not MAX485 (5 V) — the Pico is 3.3 V logic. Both are pin-compatible.
+
+### GP2 DE/RE control
+
+In firmware, GP2 must be driven **high before** sending and returned **low after** the last byte is transmitted. The UART shift register must finish before pulling DE low — use `uart_tx_wait_blocking(uart1)` before toggling GP2.
+
+---
+
+## Protocol
+
+The bus uses a lightweight request–response protocol. The GCS Pico is always master. Peripherals never transmit unsolicited except via the `/INT` line.
+
+### Frame structure
+
+```
+Byte 0:   SOF  = 0xAB          (start-of-frame, differs from CDC 0xAA)
+Byte 1:   ADDR                  (peripheral address 0x01–0xFE; 0xFF = broadcast)
+Byte 2:   CMD                   (command / response type)
+Byte 3:   LEN                   (payload length, 0–255)
+Byte 4…:  PAYLOAD               (LEN bytes)
+Last:     CRC8                  (CRC-8/MAXIM over bytes 1…payload end)
+```
+
+> Broadcast frames (ADDR = 0xFF) require no response. Use for sync or global commands.
+
+### Address space
+
+| Address | Assignment |
+| --------- | ----------- |
+| 0x00 | Reserved |
+| 0x01 | Searchlight module |
+| 0x02 | Radar / rangefinder node |
+| 0x03 | Pan-tilt unit |
+| 0x04 | External lighting bar |
+| 0x05–0xFE | User-assignable |
+| 0xFF | Broadcast |
+
+Addresses should be configured via DIP switches or solder jumpers on each peripheral board.
+
+### Command types (CMD byte)
+
+| CMD | Direction | Name | Description |
+| ----- | ----------- | ------ | ------------- |
+| 0x01 | Master → Slave | PING | Alive check. Slave responds with PONG |
+| 0x02 | Slave → Master | PONG | Response to PING. Payload: 1-byte firmware version |
+| 0x10 | Master → Slave | SET_OUTPUT | Set a digital/PWM output. Payload: `channel (u8), value (u8)` |
+| 0x11 | Master → Slave | GET_STATUS | Request full status packet from peripheral |
+| 0x12 | Slave → Master | STATUS | Status response. Payload: peripheral-defined struct |
+| 0x20 | Master → Slave | SET_PARAM | Write a configuration parameter. Payload: `param_id (u8), value (u16)` |
+| 0x21 | Master → Slave | GET_PARAM | Read a configuration parameter. Payload: `param_id (u8)` |
+| 0x22 | Slave → Master | PARAM_VAL | Response to GET_PARAM. Payload: `param_id (u8), value (u16)` |
+| 0x30 | Master → Slave | STREAM_ON | Start periodic status broadcast at given interval. Payload: `interval_ms (u16)` |
+| 0x31 | Master → Slave | STREAM_OFF | Stop periodic streaming |
+| 0x32 | Slave → Master | STREAM_DATA | Periodic data frame. Payload: peripheral-defined |
+| 0xF0 | Slave → Master | ERROR | Error report. Payload: `error_code (u8)` |
+| 0xFF | Broadcast | SYNC | Global time sync. Payload: `timestamp_ms (u32)` |
+
+### Timing
+
+| Parameter | Value |
+| --- | --- |
+| Inter-frame gap | ≥ 2 ms |
+| Slave response timeout | 50 ms |
+| PING interval (health check) | 1000 ms per device |
+| Max retries on timeout | 3, then flag device offline |
+
+### CRC-8 polynomial
+
+`x^8 + x^5 + x^4 + 1` (0x31, Dallas/Maxim). Simple to implement on any MCU, no library needed.
+
+```c
+uint8_t crc8(const uint8_t *data, size_t len) {
+    uint8_t crc = 0x00;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 0x80) ? (crc << 1) ^ 0x31 : (crc << 1);
+    }
+    return crc;
+}
+```
+
+---
+
+## Peripheral MCU Recommendation
+
+Any MCU with a UART works. Suggested options for new peripheral boards:
+
+| MCU | Why |
+| ----- | ----- |
+| **RP2040 (Pico)** | Same toolchain as GCS, cheap, plenty of I/O |
+| **STM32G031** | Tiny, cheap, low power, SOIC-8 or TSSOP-20 |
+| **ATmega328P** | Arduino ecosystem, easy prototyping |
+| **CH32V003** | Extremely cheap (< €0.15), RISC-V, SOIC-8 |
+
+Each peripheral board needs a **SP3485** (or MAX485 if running at 5 V logic) plus the protection components listed above.
+
+---
+
+## Example Peripheral: Searchlight Module
+
+**Purpose:** High-power LED spotlight with PWM brightness control and thermal monitoring.
+
+**Hardware:**
+
+- MCU: RP2040 or STM32G031
+- SP3485 for RS-485
+- MOSFET (e.g. IRLZ44N) to switch the LED load from VBAT
+- NTC thermistor on the LED heatsink
+- Onboard fuse for VBAT
+
+**Protocol usage:**
+
+| CMD | Payload | Effect |
+| ----- | --------- | -------- |
+| `SET_OUTPUT` | `ch=0, val=0–255` | PWM brightness (0 = off, 255 = full) |
+| `GET_STATUS` | — | Returns: `brightness (u8), temp_C (i8), fault_flags (u8)` |
+| `SET_PARAM` | `param=0x01, val=1` | Enable thermal shutoff at 80 °C |
+
+**Fault flags byte:**
+
+| Bit | Meaning |
+| ----- | --------- |
+| 0 | Overcurrent |
+| 1 | Overtemperature |
+| 2 | VBAT undervoltage |
+| 3–7 | Reserved |
+
+When a fault is detected the module sends an `ERROR` frame and asserts `/INT`.
+
+---
+
+## Example Peripheral: Radar / Rangefinder Node
+
+**Purpose:** Relay distance and detection data from a radar or laser rangefinder to the GCS.
+
+**Hardware:**
+
+- MCU: RP2040 or STM32
+- SP3485 for RS-485
+- Sensor connected via secondary UART or I2C on the peripheral MCU (e.g. TF-Luna LiDAR via UART, or LD06 radar via UART)
+
+**Protocol usage:**
+
+| CMD | Payload | Effect |
+| ----- | --------- | -------- |
+| `STREAM_ON` | `interval=100` | Stream detection data every 100 ms |
+| `STREAM_DATA` | `distance_mm (u16), signal_strength (u8), status (u8)` | Periodic reading |
+| `GET_STATUS` | — | Returns: `mode (u8), range_max_m (u8), sample_rate_hz (u8)` |
+| `SET_PARAM` | `param=0x01, val=<mm>` | Set minimum detection threshold |
+
+---
+
+## Example Peripheral: Pan-Tilt Unit
+
+**Purpose:** Two-axis servo-driven camera or sensor mount, controllable from the GCS.
+
+**Hardware:**
+
+- MCU: RP2040
+- SP3485 for RS-485
+- 2× servo PWM output (pan + tilt)
+- Optional: 2× encoder feedback or potentiometer for position readback
+
+**Protocol usage:**
+
+| CMD | Payload | Effect |
+| ----- | --------- | -------- |
+| `SET_OUTPUT` | `ch=0, val=0–180` | Pan angle in degrees |
+| `SET_OUTPUT` | `ch=1, val=0–180` | Tilt angle in degrees |
+| `GET_STATUS` | — | Returns: `pan_deg (u8), tilt_deg (u8), moving (u8)` |
+| `SET_PARAM` | `param=0x01, val=<deg/s>` | Set slew rate limit |
+| `SET_PARAM` | `param=0x02, val=1` | Enable soft limits |
+
+---
+
+## Example Peripheral: External Lighting Bar
+
+**Purpose:** Addressable LED bar (e.g. SK6812) for area illumination or status indication, driven by a dedicated peripheral MCU rather than the main GCS Pico chain.
+
+**Hardware:**
+
+- MCU: RP2040 or ATmega328P
+- SP3485 for RS-485
+- PIO/timer output to SK6812 strip
+- Powered from VBAT via MOSFET switch
+
+**Protocol usage:**
+
+| CMD | Payload | Effect |
+| ----- | --------- | -------- |
+| `SET_OUTPUT` | `ch=0, val=0–255` | Global brightness |
+| `SET_PARAM` | `param=0x01, val=<mode>` | Set lighting mode (0=solid, 1=flash, 2=breathe) |
+| `SET_PARAM` | `param=0x02, val=<colour>` | Set colour (packed RGB u16: RRRRRGGGGGGBBBBB) |
+| `STREAM_ON` | `interval=500` | Stream power draw estimate every 500 ms |
+
+---
+
+## Integration with GCS Firmware
+
+### 1. New pin definitions — `src/pins.h`
+
+Add the following block:
+
+```c
+/* ------------------------------------------------------------------ */
+/* UART1 — RS-485 peripheral bus (GP8/GP9 + GP2 DE/RE)                 */
+/* ------------------------------------------------------------------ */
+#define PIN_RS485_TX        8   /* GP8  — UART1 TX → SP3485 DI          */
+#define PIN_RS485_RX        9   /* GP9  — UART1 RX ← SP3485 RO          */
+#define PIN_RS485_DE        2   /* GP2  — SP3485 DE + /RE (active high)  */
+#define PIN_RS485_INT       6   /* GP6  — /INT input (active low, pulled */
+                                /*         high; peripheral open-drains) */
+#define RS485_UART_INST     uart1
+#define RS485_BAUD          115200
+```
+
+---
+
+### 2. New CDC packet types — `src/protocol.h`
+
+Append to the existing `PROTO_TYPE_*` defines:
+
+```c
+#define PROTO_TYPE_PERIPH_CMD   0x0C  /* Pi→Pico:  command for a bus peripheral  */
+#define PROTO_TYPE_PERIPH_DATA  0x0D  /* Pico→Pi:  data from a bus peripheral    */
+#define PROTO_TYPE_PERIPH_STATE 0x0E  /* Pico→Pi:  peripheral online/offline     */
+```
+
+Add the corresponding payload structs:
+
+```c
+/* Type 0x0C — Peripheral command (Pi → Pico → RS-485 bus) */
+typedef struct __attribute__((packed)) {
+    uint8_t addr;       /* target peripheral address (0x01–0xFE) */
+    uint8_t cmd;        /* RS-485 bus CMD byte                   */
+    uint8_t len;        /* payload byte count (0–255)            */
+    uint8_t payload[];  /* flexible array — len bytes            */
+} periph_cmd_t;
+
+/* Type 0x0D — Peripheral data (RS-485 bus → Pico → Pi) */
+typedef struct __attribute__((packed)) {
+    uint8_t addr;       /* source peripheral address             */
+    uint8_t cmd;        /* RS-485 CMD byte of the response       */
+    uint8_t len;        /* payload byte count                    */
+    uint8_t payload[];  /* response payload — len bytes          */
+} periph_data_t;
+
+/* Type 0x0E — Peripheral presence notification */
+typedef struct __attribute__((packed)) {
+    uint8_t addr;       /* peripheral address                    */
+    uint8_t online;     /* 1 = online, 0 = offline               */
+} periph_state_t;
+```
+
+---
+
+### 3. Handle the new CDC packet type — `src/protocol.c`
+
+In `proto_handle_rx()`, add a case inside the checksum-verified `switch (s_rx_type)` block (after `PROTO_TYPE_WARNING`):
+
+```c
+case PROTO_TYPE_PERIPH_CMD:
+    /* Forward to rs485_task via its command queue */
+    if (s_rx_len >= 3) {
+        rs485_forward_cmd(s_rx_buf, s_rx_len);
+    }
+    break;
+```
+
+`rs485_forward_cmd()` is declared in `rs485.h` and posts to the RS-485 task queue.
+
+Also add the include at the top of `protocol.c`:
+
+```c
+#include "rs485.h"
+```
+
+---
+
+### 4. New RS-485 driver — `src/rs485.h` / `src/rs485.c`
+
+Create these two new files.
+
+**`src/rs485.h`**
+
+```c
+#ifndef RS485_H
+#define RS485_H
+
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* RS-485 bus frame SOF — distinct from CDC SOF (0xAA) */
+#define RS485_SOF   0xAB
+
+/* RS-485 CMD bytes */
+#define RS485_CMD_PING          0x01
+#define RS485_CMD_PONG          0x02
+#define RS485_CMD_SET_OUTPUT    0x10
+#define RS485_CMD_GET_STATUS    0x11
+#define RS485_CMD_STATUS        0x12
+#define RS485_CMD_SET_PARAM     0x20
+#define RS485_CMD_GET_PARAM     0x21
+#define RS485_CMD_PARAM_VAL     0x22
+#define RS485_CMD_STREAM_ON     0x30
+#define RS485_CMD_STREAM_OFF    0x31
+#define RS485_CMD_STREAM_DATA   0x32
+#define RS485_CMD_ERROR         0xF0
+#define RS485_CMD_SYNC          0xFF
+
+#define RS485_ADDR_BROADCAST    0xFF
+#define RS485_TIMEOUT_MS        50
+#define RS485_PING_INTERVAL_MS  1000
+#define RS485_MAX_PERIPHERALS   8
+
+void rs485_init(void);
+void rs485_task(void *arg);
+void rs485_forward_cmd(const uint8_t *payload, uint16_t len);
+
+#endif /* RS485_H */
+```
+
+**`src/rs485.c` — structure outline**
+
+```c
+#include "rs485.h"
+#include "pins.h"
+#include "protocol.h"
+#include "hardware/uart.h"
+#include "hardware/gpio.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include <string.h>
+
+/* ---- internal command queue (from CDC → RS-485 task) ---- */
+#define RS485_CMD_QUEUE_DEPTH  8
+#define RS485_CMD_BUF_SIZE     64
+
+typedef struct {
+    uint8_t buf[RS485_CMD_BUF_SIZE];
+    uint8_t len;
+} rs485_cmd_item_t;
+
+static QueueHandle_t s_cmd_queue;
+
+/* ---- peripheral registry ---- */
+static uint8_t s_known_addrs[RS485_MAX_PERIPHERALS] = {
+    0x01, 0x02, 0x03, 0x04,   /* extend as you add devices */
+    0x00, 0x00, 0x00, 0x00
+};
+static bool s_online[RS485_MAX_PERIPHERALS];
+
+/* ---- CRC-8/MAXIM ---- */
+static uint8_t crc8(const uint8_t *data, size_t len) {
+    uint8_t crc = 0x00;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 0x80) ? (crc << 1) ^ 0x31 : (crc << 1);
+    }
+    return crc;
+}
+
+/* ---- transmit one RS-485 frame ---- */
+static void rs485_send(uint8_t addr, uint8_t cmd,
+                       const uint8_t *payload, uint8_t plen)
+{
+    uint8_t frame[4 + 255 + 1];
+    frame[0] = RS485_SOF;
+    frame[1] = addr;
+    frame[2] = cmd;
+    frame[3] = plen;
+    if (plen) memcpy(&frame[4], payload, plen);
+    frame[4 + plen] = crc8(&frame[1], 3 + plen);
+
+    gpio_put(PIN_RS485_DE, 1);          /* enable driver  */
+    uart_write_blocking(RS485_UART_INST, frame, 5 + plen);
+    uart_tx_wait_blocking(RS485_UART_INST);
+    gpio_put(PIN_RS485_DE, 0);          /* back to receive */
+}
+
+/* ---- receive one RS-485 frame (blocking with timeout) ---- */
+/* Returns payload length on success, -1 on timeout/CRC error */
+static int rs485_recv(uint8_t *addr_out, uint8_t *cmd_out,
+                      uint8_t *buf, uint8_t buf_size)
+{
+    /* ... byte-by-byte state machine with xTaskGetTickCount() timeout ... */
+    /* Same pattern as proto_handle_rx() in protocol.c                      */
+}
+
+/* ---- report peripheral state change to Pi over CDC ---- */
+static void notify_state(uint8_t addr, bool online)
+{
+    periph_state_t pkt = { .addr = addr, .online = online ? 1 : 0 };
+    tx_item_t item;
+    int len = proto_serialize(item.buf, sizeof(item.buf),
+                              PROTO_TYPE_PERIPH_STATE,
+                              (const uint8_t *)&pkt, sizeof(pkt));
+    if (len > 0) {
+        item.len = (uint8_t)len;
+        xQueueSend(g_tx_queue, &item, 0);
+    }
+}
+
+/* ---- forward RS-485 response to Pi over CDC ---- */
+static void forward_to_pi(uint8_t addr, uint8_t cmd,
+                           const uint8_t *payload, uint8_t plen)
+{
+    uint8_t cdc_payload[2 + 255];
+    cdc_payload[0] = addr;
+    cdc_payload[1] = cmd;
+    if (plen) memcpy(&cdc_payload[2], payload, plen);
+
+    tx_item_t item;
+    int len = proto_serialize(item.buf, sizeof(item.buf),
+                              PROTO_TYPE_PERIPH_DATA,
+                              cdc_payload, 2 + plen);
+    if (len > 0) {
+        item.len = (uint8_t)len;
+        xQueueSend(g_tx_queue, &item, 0);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+void rs485_init(void)
+{
+    s_cmd_queue = xQueueCreate(RS485_CMD_QUEUE_DEPTH, sizeof(rs485_cmd_item_t));
+
+    uart_init(RS485_UART_INST, RS485_BAUD);
+    gpio_set_function(PIN_RS485_TX, GPIO_FUNC_UART);
+    gpio_set_function(PIN_RS485_RX, GPIO_FUNC_UART);
+
+    gpio_init(PIN_RS485_DE);
+    gpio_set_dir(PIN_RS485_DE, GPIO_OUT);
+    gpio_put(PIN_RS485_DE, 0);   /* receive mode by default */
+
+    gpio_init(PIN_RS485_INT);
+    gpio_set_dir(PIN_RS485_INT, GPIO_IN);
+    gpio_pull_up(PIN_RS485_INT); /* open-drain line — pulled high at rest */
+}
+
+void rs485_forward_cmd(const uint8_t *payload, uint16_t len)
+{
+    if (!s_cmd_queue || len > RS485_CMD_BUF_SIZE) return;
+    rs485_cmd_item_t item;
+    memcpy(item.buf, payload, len);
+    item.len = (uint8_t)len;
+    xQueueSend(s_cmd_queue, &item, 0);
+}
+
+/* ------------------------------------------------------------------ */
+void rs485_task(void *arg)
+{
+    (void)arg;
+    TickType_t last_ping = xTaskGetTickCount();
+    uint8_t    resp_buf[255];
+    uint8_t    resp_addr, resp_cmd;
+
+    for (;;) {
+        /* 1. Forward any commands queued from the Pi */
+        rs485_cmd_item_t cmd;
+        while (xQueueReceive(s_cmd_queue, &cmd, 0) == pdTRUE) {
+            if (cmd.len >= 3) {
+                rs485_send(cmd.buf[0], cmd.buf[1],
+                           &cmd.buf[3], cmd.buf[2]);
+                int r = rs485_recv(&resp_addr, &resp_cmd,
+                                   resp_buf, sizeof(resp_buf));
+                if (r >= 0)
+                    forward_to_pi(resp_addr, resp_cmd, resp_buf, (uint8_t)r);
+            }
+        }
+
+        /* 2. Check /INT line — any peripheral asserting an async event */
+        if (!gpio_get(PIN_RS485_INT)) {
+            /* Line is low — poll all known peripherals for status */
+            for (int i = 0; i < RS485_MAX_PERIPHERALS; i++) {
+                if (!s_known_addrs[i] || !s_online[i]) continue;
+                rs485_send(s_known_addrs[i], RS485_CMD_GET_STATUS, NULL, 0);
+                int r = rs485_recv(&resp_addr, &resp_cmd,
+                                   resp_buf, sizeof(resp_buf));
+                if (r >= 0)
+                    forward_to_pi(resp_addr, resp_cmd, resp_buf, (uint8_t)r);
+            }
+        }
+
+        /* 3. Periodic PING sweep */
+        if ((xTaskGetTickCount() - last_ping) >= pdMS_TO_TICKS(RS485_PING_INTERVAL_MS)) {
+            last_ping = xTaskGetTickCount();
+            for (int i = 0; i < RS485_MAX_PERIPHERALS; i++) {
+                if (!s_known_addrs[i]) continue;
+                rs485_send(s_known_addrs[i], RS485_CMD_PING, NULL, 0);
+                int r = rs485_recv(&resp_addr, &resp_cmd,
+                                   resp_buf, sizeof(resp_buf));
+                bool now_online = (r >= 0 && resp_cmd == RS485_CMD_PONG);
+                if (now_online != s_online[i]) {
+                    s_online[i] = now_online;
+                    notify_state(s_known_addrs[i], now_online);
+                }
+            }
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}
+```
+
+---
+
+### 5. Register the task — `src/main.c`
+
+In `main()` after the existing task creations, add:
+
+```c
+#include "rs485.h"
+
+/* ... existing task creates ... */
+
+rs485_init();
+xTaskCreate(rs485_task, "rs485", 512, NULL, 2, NULL);
+```
+
+Priority 2 — same as `cdc_task`, below `usb_device_task` (4).
+
+---
+
+### 6. Summary of all file changes
+
+| File | Change |
+|------|--------|
+| `src/pins.h` | Add `PIN_RS485_TX`, `PIN_RS485_RX`, `PIN_RS485_DE`, `RS485_UART_INST`, `RS485_BAUD` |
+| `src/protocol.h` | Add `PROTO_TYPE_PERIPH_CMD/DATA/STATE` and three new packet structs |
+| `src/protocol.c` | Add `#include "rs485.h"` and `case PROTO_TYPE_PERIPH_CMD` in `proto_handle_rx()` |
+| `src/rs485.h` | New file — RS-485 constants and public API |
+| `src/rs485.c` | New file — UART1 init, DE/RE control, frame TX/RX, FreeRTOS task |
+| `src/main.c` | Call `rs485_init()` and `xTaskCreate(rs485_task, ...)` |
+| `CMakeLists.txt` | Add `rs485.c` to the target sources |
+
+---
+
+## Peripheral Status Screens
+
+The GCS ST7735 display (128×128 px) can show peripheral bus status. Two new screen modes are added: a **peripheral overview** listing all known devices and their online/offline state, and a **peripheral detail** view showing live data from a single selected device. The Pi can switch to these screens via the existing CDC screen-mode command (type `0x04`).
+
+### Screen modes
+
+| Mode ID | Name | Description |
+|---------|------|-------------|
+| `5` | `SCREEN_MODE_PERIPH` | Overview — list of all peripherals with online/offline status |
+| `6` | `SCREEN_MODE_PERIPH_DETAIL` | Detail — live telemetry from one selected peripheral |
+
+### Peripheral overview screen (mode 5)
+
+```
+┌────────────────────────────┐
+│  ▓▓ PERIPHERALS ▓▓  (navy)│  ← header, teal accent line
+├────────────────────────────┤
+│  0x01 Searchlight  [ONLINE]│  ← green pill if online
+│  0x02 Radar        [OFFLN] │  ← red pill if offline
+│  0x03 Pan-Tilt     [ONLINE]│
+│  0x04 Light Bar    [OFFLN] │
+│                            │
+│                            │
+│  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  │
+│  4 devices  2 online (teal)│  ← footer summary
+└────────────────────────────┘
+```
+
+Each peripheral row shows:
+- Address (hex, 4 chars)
+- Short name (up to 10 chars, looked up from a name table)
+- Status pill: green `ON` or red `OFF`
+
+The screen refreshes when `periph_state_t` packets (type `0x0E`) arrive over CDC, updating the cached online/offline flags. Up to 8 peripherals fit on the 128 px display (8 rows × 10 px row height + header + footer).
+
+### Peripheral detail screen (mode 6)
+
+The detail screen shows live data from one peripheral. The Pi selects which peripheral to display via a new CDC packet type (see below). The layout adapts based on the peripheral type.
+
+**Searchlight detail example:**
+
+```
+┌────────────────────────────┐
+│  ▓▓ SEARCHLIGHT ▓▓ (navy) │  ← header with device name
+├────────────────────────────┤
+│  Brightness       ███████  │  ← bar graph, 0–255
+│                    78%     │
+│                            │
+│  Temp              42°C    │  ← colour-coded (green/amber/red)
+│                            │
+│  Faults           NONE     │  ← or list active fault flags
+│                            │
+│  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓    │
+│  addr 0x01    ONLINE       │  ← footer with address + status
+└────────────────────────────┘
+```
+
+**Radar detail example:**
+
+```
+┌────────────────────────────┐
+│  ▓▓ RADAR NODE ▓▓  (navy) │
+├────────────────────────────┤
+│  Distance                  │
+│        1234 mm             │  ← size 2 font
+│                            │
+│  Signal       ████░░░░    │  ← strength bar
+│  Status       OK          │
+│                            │
+│  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  │
+│  addr 0x02    ONLINE      │
+└────────────────────────────┘
+```
+
+### Peripheral name table
+
+A static lookup table maps addresses to short display names. Default entries match the address space defined earlier in this document:
+
+```c
+static const char *periph_name(uint8_t addr) {
+    switch (addr) {
+        case 0x01: return "Searchlight";
+        case 0x02: return "Radar";
+        case 0x03: return "Pan-Tilt";
+        case 0x04: return "Light Bar";
+        default:   return "Device";
+    }
+}
+```
+
+### Navigating between screens
+
+The Pi controls which screen is displayed via the existing screen-mode CDC packet (`PROTO_TYPE_SCREEN`, type `0x04`). To show the detail view for a specific peripheral, a new CDC packet type is added:
+
+| Type | Direction | Name | Payload |
+|------|-----------|------|---------|
+| `0x0F` | Pi → Pico | `PROTO_TYPE_PERIPH_SCREEN` | `addr (u8)` — peripheral to show in detail view |
+
+When the Pico receives this packet, it caches the target address and switches to `SCREEN_MODE_PERIPH_DETAIL`. Subsequent `STREAM_DATA` or `STATUS` frames from that address are rendered on the detail screen.
+
+The overview screen can also be triggered by a physical switch (e.g. SW3 position) via the auto-mode state machine, allowing the operator to check peripheral status without Pi intervention.
+
+---
+
+## PCB Layout Notes
+
+- Place the SP3485 as close to the 8-pin rear connector as possible — keep A/B traces short before the TVS diodes.
+- Route A and B as a differential pair with matched length; keep away from the 5 V LED supply traces.
+- Place 120 Ω termination resistor directly at the connector pad (not at the SP3485).
+- Place 560 Ω bias resistors (A to **3.3 V**, B to GND) near the SP3485 — these ensure a defined idle state when no peripheral is connected.
+- The polyfuse on VBAT should be the first component after the connector pin, before any branching.
+- Add a LED (with 1 kΩ resistor) on the DE line to indicate when the bus is transmitting — useful for debugging in the field.

--- a/Peripherals/Framework/README.md
+++ b/Peripherals/Framework/README.md
@@ -1,0 +1,57 @@
+# RS-485 Peripheral Slave Framework
+
+Reusable slave-side library for the GCS RS-485 peripheral bus. Targets
+**RP2040**, **STM32G031**, and **ESP32** out of the box. New peripheral
+boards write only their command handlers and a small `board_<mcu>.c`.
+
+The bus protocol is defined in
+[`../Docs/RS485_PERIPHERAL_BUS.md`](../Docs/RS485_PERIPHERAL_BUS.md).
+
+## Layout
+
+```
+core/   portable C — framing FSM, CRC, dispatch, PING/PONG, STREAM, /INT
+hal/    one .c per MCU implementing the 8-function hal.h interface
+cmake/  framework.cmake + per-MCU back-ends (rp2040 / stm32g0 / esp32)
+```
+
+## Writing a new peripheral
+
+1. Pick an address (`Docs/RS485_PERIPHERAL_BUS.md` § Address space).
+2. Create `MyPeriph/src/main.c`, `src/board.h`, and one
+   `src/board_<mcu>.c` per MCU you want to support.
+3. In `main.c`, declare a `rs485_handler_t[]` and call
+   `rs485_slave_init(&cfg)` + `rs485_slave_poll()` in a loop.
+4. Add a `MyPeriph/CMakeLists.txt` that includes `framework.cmake`
+   and calls `add_peripheral(NAME … MCU … SOURCES …)`.
+5. Build: `cmake -B build -DTARGET_MCU=rp2040 . && cmake --build build`.
+
+`Searchlight/`, `PanTilt/`, `LightBar/` are working examples.
+
+## Porting to a new MCU
+
+Implement the 8 functions in `hal/hal.h` against your SDK and add a
+`cmake/<mcu>.cmake` back-end mirroring `rp2040.cmake`. The portable core
+in `core/rs485_slave.c` does not include any MCU header — verified by
+compiling it with `-ffreestanding` against a stub HAL.
+
+## MCU back-ends
+
+| MCU | UART | DE pin | Time | Build prereq |
+|---|---|---|---|---|
+| RP2040 | `uart0` GP0/GP1 | GP2 (GPIO) | `to_ms_since_boot` | `PICO_SDK_PATH` env or `-DPICO_SDK_PATH=…` |
+| STM32G031 | USART1 PA9/PA10 | PA8 (GPIO) | SysTick @ 1 kHz | `arm-none-eabi-gcc` on PATH; CMSIS pulled via FetchContent |
+| ESP32 | `UART1` configurable | RTS pin (driver auto-toggle) | `esp_timer_get_time` | ESP-IDF v5.x sourced (`IDF_PATH` set) |
+
+Pin defaults are overridable: pass `-DHAL_<MCU>_PIN_<…>=<n>` at compile
+time, or `#define` before including the HAL header.
+
+## Out of scope (v1)
+
+- CH32V003 HAL (mentioned in the spec; not requested yet).
+- Async TX (interrupt/DMA-driven); v1 uses blocking `hal_uart_write`.
+- Bootloader / OTA over RS-485.
+- Persistent param storage in flash — handlers hold defaults at boot.
+- Discovery / hot-plug; the master keeps a static address list.
+- Real SK6812 PIO drive in `LightBar` — the app tracks state and exposes
+  a power-estimate stream; pixel push is left to a follow-up.

--- a/Peripherals/Framework/cmake/esp32.cmake
+++ b/Peripherals/Framework/cmake/esp32.cmake
@@ -1,0 +1,39 @@
+# ESP32 backend for the peripheral framework.
+#
+# ESP-IDF has its own component-based build system on top of CMake. The
+# right way to consume the framework from ESP-IDF is to register it as
+# a component, not to call add_executable directly. This file provides
+# that bridge so apps can keep the same `add_peripheral(... MCU esp32 ...)`
+# call as the other MCUs.
+#
+# Build prerequisites:
+#   - ESP-IDF v5.x set up (idf.py exports IDF_PATH)
+#   - The app directory must contain an idf.py-compatible project
+#     skeleton (sdkconfig defaults, CMakeLists.txt that does
+#     `include($ENV{IDF_PATH}/tools/cmake/project.cmake)`).
+#
+# When TARGET_MCU=esp32, the app's own CMakeLists is expected to be a
+# regular IDF project. add_peripheral() then declares an IDF component
+# from the framework + HAL sources and links it into the main app.
+
+if(NOT DEFINED ENV{IDF_PATH})
+    message(FATAL_ERROR
+        "esp32.cmake: IDF_PATH not set. Source ESP-IDF's export.sh first.")
+endif()
+
+function(_peripheral_esp32 NAME SOURCES)
+    # Register a private component carrying the framework core + ESP HAL.
+    idf_component_register(
+        SRCS
+            ${PERIPH_CORE_SOURCES}
+            ${PERIPH_FRAMEWORK_DIR}/hal/hal_esp32.c
+            ${SOURCES}
+        INCLUDE_DIRS
+            ${PERIPH_CORE_INCLUDES}
+        REQUIRES
+            driver
+            esp_timer
+    )
+    # The IDF flow produces NAME.bin/elf via idf.py build — no extra
+    # post-build step needed here.
+endfunction()

--- a/Peripherals/Framework/cmake/framework.cmake
+++ b/Peripherals/Framework/cmake/framework.cmake
@@ -1,0 +1,42 @@
+# RS-485 peripheral slave framework — top-level CMake entry point.
+#
+# Apps include this file and call:
+#   add_peripheral(NAME <app> MCU <rp2040|stm32g0|esp32> SOURCES <files…>)
+#
+# The MCU dispatcher pulls in the per-MCU toolchain + SDK and adds the
+# framework's portable core + the matching HAL.
+
+set(PERIPH_FRAMEWORK_DIR ${CMAKE_CURRENT_LIST_DIR}/.. CACHE INTERNAL "")
+set(PERIPH_CMAKE_DIR     ${CMAKE_CURRENT_LIST_DIR}    CACHE INTERNAL "")
+
+set(PERIPH_CORE_SOURCES
+    ${PERIPH_FRAMEWORK_DIR}/core/crc8.c
+    ${PERIPH_FRAMEWORK_DIR}/core/rs485_slave.c
+    CACHE INTERNAL ""
+)
+set(PERIPH_CORE_INCLUDES
+    ${PERIPH_FRAMEWORK_DIR}/core
+    ${PERIPH_FRAMEWORK_DIR}/hal
+    CACHE INTERNAL ""
+)
+
+function(add_peripheral)
+    cmake_parse_arguments(P "" "NAME;MCU" "SOURCES" ${ARGN})
+    if(NOT P_NAME OR NOT P_MCU)
+        message(FATAL_ERROR "add_peripheral: NAME and MCU are required")
+    endif()
+
+    if(P_MCU STREQUAL "rp2040")
+        include(${PERIPH_CMAKE_DIR}/rp2040.cmake)
+        _peripheral_rp2040(${P_NAME} "${P_SOURCES}")
+    elseif(P_MCU STREQUAL "stm32g0")
+        include(${PERIPH_CMAKE_DIR}/stm32g0.cmake)
+        _peripheral_stm32g0(${P_NAME} "${P_SOURCES}")
+    elseif(P_MCU STREQUAL "esp32")
+        include(${PERIPH_CMAKE_DIR}/esp32.cmake)
+        _peripheral_esp32(${P_NAME} "${P_SOURCES}")
+    else()
+        message(FATAL_ERROR "add_peripheral: unknown MCU '${P_MCU}' "
+                            "(expected rp2040 | stm32g0 | esp32)")
+    endif()
+endfunction()

--- a/Peripherals/Framework/cmake/rp2040.cmake
+++ b/Peripherals/Framework/cmake/rp2040.cmake
@@ -1,0 +1,42 @@
+# RP2040 backend for the peripheral framework.
+#
+# Pulls the Raspberry Pi Pico SDK (via PICO_SDK_PATH or pico-sdk install),
+# wires the framework core + RP2040 HAL, and produces a UF2 next to the
+# ELF.
+#
+# pico_sdk_init() must be called once per project. Apps may set
+# PICO_BOARD before including framework.cmake to target a specific board
+# (default = pico).
+
+if(NOT COMMAND pico_sdk_init)
+    if(NOT DEFINED PICO_SDK_PATH AND DEFINED ENV{PICO_SDK_PATH})
+        set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    endif()
+    if(NOT PICO_SDK_PATH)
+        message(FATAL_ERROR
+            "rp2040.cmake: PICO_SDK_PATH not set. "
+            "Install the Pico SDK and set the env var, or pass "
+            "-DPICO_SDK_PATH=/path/to/pico-sdk on the cmake command line.")
+    endif()
+    include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+    if(NOT DEFINED PICO_BOARD)
+        set(PICO_BOARD pico)
+    endif()
+    pico_sdk_init()
+endif()
+
+function(_peripheral_rp2040 NAME SOURCES)
+    add_executable(${NAME}
+        ${SOURCES}
+        ${PERIPH_CORE_SOURCES}
+        ${PERIPH_FRAMEWORK_DIR}/hal/hal_rp2040.c
+    )
+    target_include_directories(${NAME} PRIVATE ${PERIPH_CORE_INCLUDES})
+    target_link_libraries(${NAME}
+        pico_stdlib
+        hardware_uart
+        hardware_gpio
+        hardware_pwm
+    )
+    pico_add_extra_outputs(${NAME})   # produces NAME.uf2
+endfunction()

--- a/Peripherals/Framework/cmake/stm32g0.cmake
+++ b/Peripherals/Framework/cmake/stm32g0.cmake
@@ -1,0 +1,73 @@
+# STM32G031 backend for the peripheral framework.
+#
+# Pulls CMSIS Core (CMSIS_5) and CMSIS-Device-G0 via FetchContent so the
+# repo doesn't vendor headers. Sets the toolchain to arm-none-eabi-gcc
+# and uses ST's stock startup .s + linker script from CMSIS-Device-G0.
+#
+# Build prerequisites: arm-none-eabi-gcc on PATH (e.g. apt-get
+# install gcc-arm-none-eabi).
+
+if(NOT CMAKE_C_COMPILER MATCHES "arm-none-eabi-gcc")
+    set(CMAKE_SYSTEM_NAME      Generic)
+    set(CMAKE_SYSTEM_PROCESSOR arm)
+    set(CMAKE_C_COMPILER       arm-none-eabi-gcc)
+    set(CMAKE_ASM_COMPILER     arm-none-eabi-gcc)
+    set(CMAKE_OBJCOPY          arm-none-eabi-objcopy)
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+endif()
+
+include(FetchContent)
+FetchContent_Declare(cmsis_core
+    GIT_REPOSITORY https://github.com/ARM-software/CMSIS_5.git
+    GIT_TAG        5.9.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_Declare(cmsis_device_g0
+    GIT_REPOSITORY https://github.com/STMicroelectronics/cmsis_device_g0.git
+    GIT_TAG        v1.4.4
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(cmsis_core cmsis_device_g0)
+
+set(STM32_CFLAGS
+    -mcpu=cortex-m0plus -mthumb -mfloat-abi=soft
+    -ffunction-sections -fdata-sections -Os -g
+)
+set(STM32_LDFLAGS
+    -mcpu=cortex-m0plus -mthumb -mfloat-abi=soft
+    -Wl,--gc-sections -nostartfiles --specs=nano.specs --specs=nosys.specs
+)
+
+set(STM32G0_DEVICE_DIR ${cmsis_device_g0_SOURCE_DIR})
+set(STM32G0_STARTUP    ${STM32G0_DEVICE_DIR}/Source/Templates/gcc/startup_stm32g031xx.s)
+set(STM32G0_LINKER     ${STM32G0_DEVICE_DIR}/Source/Templates/gcc/linker/STM32G031K8Tx_FLASH.ld)
+set(STM32G0_SYSTEM     ${STM32G0_DEVICE_DIR}/Source/Templates/system_stm32g0xx.c)
+
+function(_peripheral_stm32g0 NAME SOURCES)
+    add_executable(${NAME}
+        ${SOURCES}
+        ${PERIPH_CORE_SOURCES}
+        ${PERIPH_FRAMEWORK_DIR}/hal/hal_stm32g0.c
+        ${STM32G0_STARTUP}
+        ${STM32G0_SYSTEM}
+    )
+    target_compile_definitions(${NAME} PRIVATE STM32G031xx)
+    target_compile_options(${NAME} PRIVATE ${STM32_CFLAGS})
+    target_include_directories(${NAME} PRIVATE
+        ${PERIPH_CORE_INCLUDES}
+        ${cmsis_core_SOURCE_DIR}/CMSIS/Core/Include
+        ${STM32G0_DEVICE_DIR}/Include
+    )
+    target_link_options(${NAME} PRIVATE
+        ${STM32_LDFLAGS}
+        -T${STM32G0_LINKER}
+        -Wl,-Map=${NAME}.map
+    )
+    set_target_properties(${NAME} PROPERTIES SUFFIX ".elf")
+
+    add_custom_command(TARGET ${NAME} POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${NAME}> ${NAME}.bin
+        COMMAND ${CMAKE_OBJCOPY} -O ihex   $<TARGET_FILE:${NAME}> ${NAME}.hex
+        COMMENT "Generating ${NAME}.bin / ${NAME}.hex"
+    )
+endfunction()

--- a/Peripherals/Framework/core/crc8.c
+++ b/Peripherals/Framework/core/crc8.c
@@ -1,0 +1,15 @@
+#include "crc8.h"
+
+/* CRC-8/MAXIM (polynomial 0x31, init 0x00). Identical to the master in
+   GCS/src/rs485.c so frames produced or checked here interoperate byte-
+   for-byte with the GCS bus. */
+uint8_t crc8(const uint8_t *data, size_t len)
+{
+    uint8_t crc = 0x00;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 0x80) ? (crc << 1) ^ 0x31 : (crc << 1);
+    }
+    return crc;
+}

--- a/Peripherals/Framework/core/crc8.h
+++ b/Peripherals/Framework/core/crc8.h
@@ -1,0 +1,17 @@
+#ifndef RS485_CRC8_H
+#define RS485_CRC8_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t crc8(const uint8_t *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripherals/Framework/core/rs485_proto.h
+++ b/Peripherals/Framework/core/rs485_proto.h
@@ -1,0 +1,36 @@
+#ifndef RS485_PROTO_H
+#define RS485_PROTO_H
+
+/* Wire-format constants for the RS-485 peripheral bus. Mirrors
+   GCS/src/rs485.h on the master side. The authoritative spec lives in
+   Peripherals/Docs/RS485_PERIPHERAL_BUS.md. */
+
+#define RS485_SOF               0xAB
+
+/* Command bytes */
+#define RS485_CMD_PING          0x01
+#define RS485_CMD_PONG          0x02
+#define RS485_CMD_SET_OUTPUT    0x10
+#define RS485_CMD_GET_STATUS    0x11
+#define RS485_CMD_STATUS        0x12
+#define RS485_CMD_SET_PARAM     0x20
+#define RS485_CMD_GET_PARAM     0x21
+#define RS485_CMD_PARAM_VAL     0x22
+#define RS485_CMD_STREAM_ON     0x30
+#define RS485_CMD_STREAM_OFF    0x31
+#define RS485_CMD_STREAM_DATA   0x32
+#define RS485_CMD_ERROR         0xF0
+#define RS485_CMD_SYNC          0xFF
+
+#define RS485_ADDR_BROADCAST    0xFF
+
+/* Timing — must agree with the master (GCS/src/rs485.h) */
+#define RS485_TIMEOUT_MS        50
+#define RS485_INTERFRAME_GAP_MS 2
+
+/* Frame size limits */
+#define RS485_MAX_PAYLOAD       255
+#define RS485_FRAME_OVERHEAD    5    /* SOF + ADDR + CMD + LEN + CRC */
+#define RS485_MAX_FRAME         (RS485_FRAME_OVERHEAD + RS485_MAX_PAYLOAD)
+
+#endif

--- a/Peripherals/Framework/core/rs485_slave.c
+++ b/Peripherals/Framework/core/rs485_slave.c
@@ -1,0 +1,228 @@
+#include "rs485_slave.h"
+#include "crc8.h"
+#include "../hal/hal.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Internal state                                                       */
+/* ------------------------------------------------------------------ */
+
+typedef enum {
+    S_SOF = 0, S_ADDR, S_CMD, S_LEN, S_PAYLOAD, S_CRC
+} rx_state_t;
+
+static const rs485_slave_cfg_t *s_cfg;
+
+/* RX FSM */
+static rx_state_t  s_state;
+static uint8_t     s_rx_addr, s_rx_cmd, s_rx_plen, s_rx_idx;
+static uint8_t     s_rx_buf[RS485_MAX_PAYLOAD];
+static uint32_t    s_rx_t0;            /* hal_millis() when SOF arrived */
+static uint32_t    s_last_byte_ms;     /* hal_millis() of last byte seen on bus */
+
+/* Streaming */
+static uint16_t    s_stream_interval;  /* 0 = disabled */
+static uint32_t    s_stream_last_ms;
+
+/* ------------------------------------------------------------------ */
+/* Frame TX                                                             */
+/* ------------------------------------------------------------------ */
+
+static void send_frame(uint8_t addr, uint8_t cmd,
+                       const uint8_t *payload, uint8_t plen)
+{
+    uint8_t frame[RS485_MAX_FRAME];
+    frame[0] = RS485_SOF;
+    frame[1] = addr;
+    frame[2] = cmd;
+    frame[3] = plen;
+    if (plen && payload) memcpy(&frame[4], payload, plen);
+    frame[4 + plen] = crc8(&frame[1], 3 + plen);
+
+    hal_uart_set_tx_enable(true);
+    hal_uart_write(frame, 5 + plen);
+    hal_uart_set_tx_enable(false);
+}
+
+/* ------------------------------------------------------------------ */
+/* Dispatch                                                             */
+/* ------------------------------------------------------------------ */
+
+static const rs485_handler_t *find_handler(uint8_t cmd)
+{
+    if (!s_cfg || !s_cfg->handlers) return NULL;
+    for (const rs485_handler_t *h = s_cfg->handlers; h->cmd != 0; h++) {
+        if (h->cmd == cmd) return h;
+    }
+    return NULL;
+}
+
+static void dispatch(uint8_t addr, uint8_t cmd,
+                     const uint8_t *payload, uint8_t plen)
+{
+    const bool broadcast = (addr == RS485_ADDR_BROADCAST);
+
+    /* Built-in: PING -> PONG with [fw_version]. Skip on broadcast. */
+    if (cmd == RS485_CMD_PING) {
+        if (!broadcast) {
+            uint8_t fw = s_cfg->fw_version;
+            send_frame(s_cfg->addr, RS485_CMD_PONG, &fw, 1);
+        }
+        return;
+    }
+
+    /* Built-in: STREAM_ON / STREAM_OFF */
+    if (cmd == RS485_CMD_STREAM_ON) {
+        if (s_cfg->build_stream && plen >= 2) {
+            s_stream_interval = (uint16_t)(payload[0] | (payload[1] << 8));
+            s_stream_last_ms  = hal_millis();
+        }
+        return;
+    }
+    if (cmd == RS485_CMD_STREAM_OFF) {
+        s_stream_interval = 0;
+        return;
+    }
+
+    /* App handlers */
+    const rs485_handler_t *h = find_handler(cmd);
+    if (!h) return;   /* silently ignore unknown CMDs — keeps the bus quiet */
+
+    if (broadcast) {
+        h->handler(payload, plen, NULL, 0);
+        return;
+    }
+
+    uint8_t resp[RS485_MAX_PAYLOAD];
+    int rlen = h->handler(payload, plen, resp, sizeof(resp));
+    if (rlen < 0) return;
+    if (rlen > (int)sizeof(resp)) rlen = sizeof(resp);
+
+    /* Reply CMD: STATUS for GET_STATUS, PARAM_VAL for GET_PARAM, otherwise
+       echo the request CMD as an ack. */
+    uint8_t reply_cmd = cmd;
+    if (cmd == RS485_CMD_GET_STATUS) reply_cmd = RS485_CMD_STATUS;
+    else if (cmd == RS485_CMD_GET_PARAM) reply_cmd = RS485_CMD_PARAM_VAL;
+
+    send_frame(s_cfg->addr, reply_cmd, resp, (uint8_t)rlen);
+}
+
+/* ------------------------------------------------------------------ */
+/* RX FSM                                                               */
+/* ------------------------------------------------------------------ */
+
+static void rx_reset(void) { s_state = S_SOF; }
+
+static void feed_byte(uint8_t b)
+{
+    s_last_byte_ms = hal_millis();
+
+    switch (s_state) {
+    case S_SOF:
+        if (b == RS485_SOF) {
+            s_state = S_ADDR;
+            s_rx_t0 = s_last_byte_ms;
+        }
+        break;
+
+    case S_ADDR:
+        s_rx_addr = b;
+        s_state   = S_CMD;
+        break;
+
+    case S_CMD:
+        s_rx_cmd = b;
+        s_state  = S_LEN;
+        break;
+
+    case S_LEN:
+        s_rx_plen = b;
+        s_rx_idx  = 0;
+        s_state   = (b == 0) ? S_CRC : S_PAYLOAD;
+        break;
+
+    case S_PAYLOAD:
+        s_rx_buf[s_rx_idx++] = b;
+        if (s_rx_idx >= s_rx_plen) s_state = S_CRC;
+        break;
+
+    case S_CRC: {
+        uint8_t hdr[3 + RS485_MAX_PAYLOAD];
+        hdr[0] = s_rx_addr; hdr[1] = s_rx_cmd; hdr[2] = s_rx_plen;
+        if (s_rx_plen) memcpy(&hdr[3], s_rx_buf, s_rx_plen);
+        if (b == crc8(hdr, 3 + s_rx_plen)) {
+            if (s_rx_addr == s_cfg->addr ||
+                s_rx_addr == RS485_ADDR_BROADCAST) {
+                dispatch(s_rx_addr, s_rx_cmd, s_rx_buf, s_rx_plen);
+            }
+        }
+        rx_reset();
+        break;
+    }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Streaming                                                            */
+/* ------------------------------------------------------------------ */
+
+static bool bus_quiet(void)
+{
+    /* Don't TX while a frame is mid-flight or the master is back-to-back. */
+    if (s_state != S_SOF) return false;
+    return (hal_millis() - s_last_byte_ms) >= RS485_INTERFRAME_GAP_MS;
+}
+
+static void stream_tick(void)
+{
+    if (!s_stream_interval || !s_cfg->build_stream) return;
+    if ((hal_millis() - s_stream_last_ms) < s_stream_interval) return;
+    if (!bus_quiet()) return;
+
+    uint8_t buf[RS485_MAX_PAYLOAD];
+    int len = s_cfg->build_stream(buf, sizeof(buf));
+    if (len < 0) return;
+    if (len > (int)sizeof(buf)) len = sizeof(buf);
+
+    send_frame(s_cfg->addr, RS485_CMD_STREAM_DATA, buf, (uint8_t)len);
+    s_stream_last_ms = hal_millis();
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                           */
+/* ------------------------------------------------------------------ */
+
+void rs485_slave_init(const rs485_slave_cfg_t *cfg)
+{
+    s_cfg = cfg;
+    rx_reset();
+    s_stream_interval = 0;
+    s_last_byte_ms    = 0;
+
+    hal_uart_init(115200);
+    hal_uart_set_tx_enable(false);
+    hal_int_pin_init();
+}
+
+void rs485_slave_poll(void)
+{
+    /* Drain any UART bytes waiting. */
+    uint8_t b;
+    while (hal_uart_read(&b)) {
+        feed_byte(b);
+    }
+
+    /* Drop a stalled mid-frame if no progress for RS485_TIMEOUT_MS. */
+    if (s_state != S_SOF &&
+        (hal_millis() - s_rx_t0) >= RS485_TIMEOUT_MS) {
+        rx_reset();
+    }
+
+    stream_tick();
+}
+
+void rs485_slave_assert_int(bool asserted)
+{
+    hal_int_pin_drive(asserted);
+}

--- a/Peripherals/Framework/core/rs485_slave.h
+++ b/Peripherals/Framework/core/rs485_slave.h
@@ -1,0 +1,46 @@
+#ifndef RS485_SLAVE_H
+#define RS485_SLAVE_H
+
+#include "rs485_proto.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Per-command handler entry. Build a response into resp_buf and return its
+   length (0..resp_buf_size). Return -1 to send no reply. For broadcast
+   frames resp_buf is NULL and the return value is ignored — handlers must
+   still apply side effects. */
+typedef struct {
+    uint8_t cmd;
+    int   (*handler)(const uint8_t *payload, uint8_t plen,
+                     uint8_t *resp_buf, uint8_t resp_buf_size);
+} rs485_handler_t;
+
+typedef struct {
+    uint8_t                 addr;          /* this slave 0x01..0xFE */
+    uint8_t                 fw_version;    /* returned in PONG payload */
+    const rs485_handler_t  *handlers;      /* terminated by .cmd == 0 */
+    /* Optional: build a STREAM_DATA payload. NULL = streaming unsupported. */
+    int (*build_stream)(uint8_t *buf, uint8_t buf_size);
+} rs485_slave_cfg_t;
+
+/* Initialise the slave. Calls hal_uart_init / hal_int_pin_init internally. */
+void rs485_slave_init(const rs485_slave_cfg_t *cfg);
+
+/* Drive the protocol. Call as fast as the loop allows — must run at least
+   once per millisecond to avoid losing bytes at 115200 baud. Non-blocking. */
+void rs485_slave_poll(void);
+
+/* Drive the /INT line. Open-drain semantics — true pulls low, false
+   releases. The line stays asserted until the caller releases it. */
+void rs485_slave_assert_int(bool asserted);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripherals/Framework/hal/hal.h
+++ b/Peripherals/Framework/hal/hal.h
@@ -1,0 +1,50 @@
+#ifndef RS485_HAL_H
+#define RS485_HAL_H
+
+/* Portable HAL interface for the RS-485 slave framework. Each MCU port
+   provides one .c file implementing every function in this header. The
+   core (rs485_slave.c) includes only this header — no MCU-specific
+   headers leak into portable code. */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Initialise the UART at `baud` (8N1, no flow control) and configure the
+   DE/RE pin as output (driven low = receive). Safe to call once at boot. */
+void hal_uart_init(uint32_t baud);
+
+/* Drive the RS-485 transceiver DE/RE pin. true = transmit, false = receive.
+   Ports that wire DE to the UART driver itself (e.g. ESP-IDF RS-485 mode)
+   may make this a no-op — the symbol must still exist. */
+void hal_uart_set_tx_enable(bool enable);
+
+/* Blocking write. Must not return until the last byte has fully clocked
+   out of the UART shift register, so the caller can deassert DE without
+   truncating the frame. */
+void hal_uart_write(const uint8_t *buf, size_t len);
+
+/* Non-blocking single-byte read. Returns 1 if a byte was available (stored
+   in *byte_out), 0 if not. Never blocks. */
+int  hal_uart_read(uint8_t *byte_out);
+
+/* Configure the /INT pin as open-drain output, idle high (de-asserted). */
+void hal_int_pin_init(void);
+
+/* Drive /INT. true = pull low (assert), false = release (pulled high by
+   the master's pull-up). */
+void hal_int_pin_drive(bool assert_low);
+
+/* Free-running millisecond counter. Wraps at 2^32 ms (~49 days) — callers
+   compare with subtraction so wrap is fine. */
+uint32_t hal_millis(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Peripherals/Framework/hal/hal_esp32.c
+++ b/Peripherals/Framework/hal/hal_esp32.c
@@ -1,0 +1,86 @@
+#include "hal.h"
+
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+
+/* Defaults — boards can override on the compiler command line. */
+#ifndef HAL_ESP32_UART
+#define HAL_ESP32_UART       UART_NUM_1
+#endif
+#ifndef HAL_ESP32_PIN_TX
+#define HAL_ESP32_PIN_TX     17
+#endif
+#ifndef HAL_ESP32_PIN_RX
+#define HAL_ESP32_PIN_RX     16
+#endif
+#ifndef HAL_ESP32_PIN_DE
+#define HAL_ESP32_PIN_DE     4              /* RTS — driver toggles this */
+#endif
+#ifndef HAL_ESP32_PIN_INT
+#define HAL_ESP32_PIN_INT    5
+#endif
+#ifndef HAL_ESP32_RX_BUF
+#define HAL_ESP32_RX_BUF     512
+#endif
+
+void hal_uart_init(uint32_t baud)
+{
+    uart_config_t cfg = {
+        .baud_rate = (int)baud,
+        .data_bits = UART_DATA_8_BITS,
+        .parity    = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_DEFAULT,
+    };
+    uart_driver_install(HAL_ESP32_UART, HAL_ESP32_RX_BUF, 0, 0, NULL, 0);
+    uart_param_config(HAL_ESP32_UART, &cfg);
+    /* DE on RTS — driver auto-toggles in RS-485 half-duplex mode. */
+    uart_set_pin(HAL_ESP32_UART,
+                 HAL_ESP32_PIN_TX, HAL_ESP32_PIN_RX,
+                 HAL_ESP32_PIN_DE, UART_PIN_NO_CHANGE);
+    uart_set_mode(HAL_ESP32_UART, UART_MODE_RS485_HALF_DUPLEX);
+}
+
+void hal_uart_set_tx_enable(bool enable)
+{
+    /* No-op: the driver toggles DE around uart_write_bytes. The function
+       must still exist so the core compiles unchanged. */
+    (void)enable;
+}
+
+void hal_uart_write(const uint8_t *buf, size_t len)
+{
+    uart_write_bytes(HAL_ESP32_UART, (const char *)buf, len);
+    uart_wait_tx_done(HAL_ESP32_UART, portMAX_DELAY);
+}
+
+int hal_uart_read(uint8_t *byte_out)
+{
+    int n = uart_read_bytes(HAL_ESP32_UART, byte_out, 1, 0);
+    return n > 0 ? 1 : 0;
+}
+
+void hal_int_pin_init(void)
+{
+    gpio_config_t io = {
+        .pin_bit_mask = (1ULL << HAL_ESP32_PIN_INT),
+        .mode         = GPIO_MODE_OUTPUT_OD,
+        .pull_up_en   = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type    = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&io);
+    gpio_set_level(HAL_ESP32_PIN_INT, 1);     /* released */
+}
+
+void hal_int_pin_drive(bool assert_low)
+{
+    gpio_set_level(HAL_ESP32_PIN_INT, assert_low ? 0 : 1);
+}
+
+uint32_t hal_millis(void)
+{
+    return (uint32_t)(esp_timer_get_time() / 1000);
+}

--- a/Peripherals/Framework/hal/hal_rp2040.c
+++ b/Peripherals/Framework/hal/hal_rp2040.c
@@ -1,0 +1,77 @@
+#include "hal.h"
+
+#include "pico/stdlib.h"
+#include "pico/time.h"
+#include "hardware/uart.h"
+#include "hardware/gpio.h"
+
+/* Pins are weak so a board can override them at link time, otherwise these
+   defaults match the master side (GCS) wiring conventions on a Pico. */
+#ifndef HAL_RP2040_UART
+#define HAL_RP2040_UART  uart0
+#endif
+#ifndef HAL_RP2040_PIN_TX
+#define HAL_RP2040_PIN_TX 0
+#endif
+#ifndef HAL_RP2040_PIN_RX
+#define HAL_RP2040_PIN_RX 1
+#endif
+#ifndef HAL_RP2040_PIN_DE
+#define HAL_RP2040_PIN_DE 2
+#endif
+#ifndef HAL_RP2040_PIN_INT
+#define HAL_RP2040_PIN_INT 3
+#endif
+
+void hal_uart_init(uint32_t baud)
+{
+    uart_init(HAL_RP2040_UART, baud);
+    gpio_set_function(HAL_RP2040_PIN_TX, GPIO_FUNC_UART);
+    gpio_set_function(HAL_RP2040_PIN_RX, GPIO_FUNC_UART);
+
+    gpio_init(HAL_RP2040_PIN_DE);
+    gpio_set_dir(HAL_RP2040_PIN_DE, GPIO_OUT);
+    gpio_put(HAL_RP2040_PIN_DE, 0);
+}
+
+void hal_uart_set_tx_enable(bool enable)
+{
+    gpio_put(HAL_RP2040_PIN_DE, enable ? 1 : 0);
+}
+
+void hal_uart_write(const uint8_t *buf, size_t len)
+{
+    uart_write_blocking(HAL_RP2040_UART, buf, len);
+    uart_tx_wait_blocking(HAL_RP2040_UART);
+}
+
+int hal_uart_read(uint8_t *byte_out)
+{
+    if (!uart_is_readable(HAL_RP2040_UART)) return 0;
+    *byte_out = (uint8_t)uart_getc(HAL_RP2040_UART);
+    return 1;
+}
+
+void hal_int_pin_init(void)
+{
+    /* Open-drain emulation: leave the pin as input (high-Z) when released
+       so the master's pull-up wins; switch to output-low to assert. */
+    gpio_init(HAL_RP2040_PIN_INT);
+    gpio_set_dir(HAL_RP2040_PIN_INT, GPIO_IN);
+    gpio_put(HAL_RP2040_PIN_INT, 0);
+}
+
+void hal_int_pin_drive(bool assert_low)
+{
+    if (assert_low) {
+        gpio_put(HAL_RP2040_PIN_INT, 0);
+        gpio_set_dir(HAL_RP2040_PIN_INT, GPIO_OUT);
+    } else {
+        gpio_set_dir(HAL_RP2040_PIN_INT, GPIO_IN);
+    }
+}
+
+uint32_t hal_millis(void)
+{
+    return (uint32_t)(to_ms_since_boot(get_absolute_time()));
+}

--- a/Peripherals/Framework/hal/hal_stm32g0.c
+++ b/Peripherals/Framework/hal/hal_stm32g0.c
@@ -1,0 +1,140 @@
+#include "hal.h"
+
+#include "stm32g0xx.h"
+
+/* ------------------------------------------------------------------ */
+/* Pin map (override at build time with -D… if a board uses different
+   pins; defaults are the most common bring-up pins on a Nucleo G031K8). */
+/* ------------------------------------------------------------------ */
+#ifndef HAL_STM32_USART
+#define HAL_STM32_USART     USART1
+#endif
+#ifndef HAL_STM32_USART_RCC_BIT
+#define HAL_STM32_USART_RCC_BIT  RCC_APBENR2_USART1EN
+#endif
+#ifndef HAL_STM32_USART_AF
+#define HAL_STM32_USART_AF  1u            /* AF1 = USART1 on PA9/PA10 */
+#endif
+#ifndef HAL_STM32_GPIO_PORT
+#define HAL_STM32_GPIO_PORT GPIOA
+#endif
+#ifndef HAL_STM32_PIN_TX
+#define HAL_STM32_PIN_TX    9u            /* PA9 */
+#endif
+#ifndef HAL_STM32_PIN_RX
+#define HAL_STM32_PIN_RX    10u           /* PA10 */
+#endif
+#ifndef HAL_STM32_PIN_DE
+#define HAL_STM32_PIN_DE    8u            /* PA8 */
+#endif
+#ifndef HAL_STM32_PIN_INT
+#define HAL_STM32_PIN_INT   7u            /* PA7 */
+#endif
+
+/* ------------------------------------------------------------------ */
+/* SysTick — 1 kHz millisecond tick                                     */
+/* ------------------------------------------------------------------ */
+
+static volatile uint32_t s_ticks;
+
+void SysTick_Handler(void)
+{
+    s_ticks++;
+}
+
+uint32_t hal_millis(void)
+{
+    return s_ticks;
+}
+
+/* ------------------------------------------------------------------ */
+/* GPIO helpers (no LL — direct register writes keep the dep surface
+/* small and the binary tiny).                                          */
+/* ------------------------------------------------------------------ */
+
+static void gpio_mode(GPIO_TypeDef *p, uint32_t pin, uint32_t mode)
+{
+    /* mode: 0 input, 1 output, 2 alt, 3 analog */
+    p->MODER = (p->MODER & ~(3u << (pin * 2))) | (mode << (pin * 2));
+}
+static void gpio_otype_od(GPIO_TypeDef *p, uint32_t pin, int open_drain)
+{
+    if (open_drain) p->OTYPER |=  (1u << pin);
+    else            p->OTYPER &= ~(1u << pin);
+}
+static void gpio_set_af(GPIO_TypeDef *p, uint32_t pin, uint32_t af)
+{
+    uint32_t idx = pin >> 3;
+    uint32_t shift = (pin & 7u) * 4u;
+    p->AFR[idx] = (p->AFR[idx] & ~(0xFu << shift)) | (af << shift);
+}
+
+/* ------------------------------------------------------------------ */
+/* HAL                                                                  */
+/* ------------------------------------------------------------------ */
+
+void hal_uart_init(uint32_t baud)
+{
+    /* Clocks */
+    RCC->IOPENR  |= RCC_IOPENR_GPIOAEN;
+    RCC->APBENR2 |= HAL_STM32_USART_RCC_BIT;
+
+    /* TX/RX = AF, DE = output push-pull */
+    gpio_mode(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_TX, 2);
+    gpio_set_af(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_TX, HAL_STM32_USART_AF);
+    gpio_mode(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_RX, 2);
+    gpio_set_af(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_RX, HAL_STM32_USART_AF);
+
+    gpio_mode(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_DE, 1);
+    HAL_STM32_GPIO_PORT->BSRR = (1u << (HAL_STM32_PIN_DE + 16));   /* low */
+
+    /* USART: assume PCLK = SystemCoreClock. Caller's startup must have
+       set SystemCoreClock; default after reset on G031 is 16 MHz HSI. */
+    extern uint32_t SystemCoreClock;
+    HAL_STM32_USART->CR1 = 0;
+    HAL_STM32_USART->BRR = SystemCoreClock / baud;
+    HAL_STM32_USART->CR1 = USART_CR1_TE | USART_CR1_RE | USART_CR1_UE;
+
+    /* SysTick at 1 kHz */
+    SysTick_Config(SystemCoreClock / 1000u);
+}
+
+void hal_uart_set_tx_enable(bool enable)
+{
+    if (enable) HAL_STM32_GPIO_PORT->BSRR = (1u << HAL_STM32_PIN_DE);
+    else        HAL_STM32_GPIO_PORT->BSRR = (1u << (HAL_STM32_PIN_DE + 16));
+}
+
+void hal_uart_write(const uint8_t *buf, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        while (!(HAL_STM32_USART->ISR & USART_ISR_TXE_TXFNF)) { }
+        HAL_STM32_USART->TDR = buf[i];
+    }
+    /* Wait for the last byte to fully clock out before releasing DE. */
+    while (!(HAL_STM32_USART->ISR & USART_ISR_TC)) { }
+}
+
+int hal_uart_read(uint8_t *byte_out)
+{
+    if (!(HAL_STM32_USART->ISR & USART_ISR_RXNE_RXFNE)) return 0;
+    *byte_out = (uint8_t)HAL_STM32_USART->RDR;
+    return 1;
+}
+
+void hal_int_pin_init(void)
+{
+    RCC->IOPENR |= RCC_IOPENR_GPIOAEN;
+    /* Open-drain output, idle high (line released — pulled high externally) */
+    gpio_otype_od(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_INT, 1);
+    HAL_STM32_GPIO_PORT->BSRR = (1u << HAL_STM32_PIN_INT);   /* release */
+    gpio_mode(HAL_STM32_GPIO_PORT, HAL_STM32_PIN_INT, 1);
+}
+
+void hal_int_pin_drive(bool assert_low)
+{
+    if (assert_low)
+        HAL_STM32_GPIO_PORT->BSRR = (1u << (HAL_STM32_PIN_INT + 16));
+    else
+        HAL_STM32_GPIO_PORT->BSRR = (1u << HAL_STM32_PIN_INT);
+}

--- a/Peripherals/LightBar/CMakeLists.txt
+++ b/Peripherals/LightBar/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT DEFINED TARGET_MCU)
+    set(TARGET_MCU rp2040 CACHE STRING "Target MCU (rp2040 | stm32g0 | esp32)")
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../Framework/cmake/framework.cmake)
+
+project(lightbar C ASM)
+
+set(BOARD_FILE ${CMAKE_CURRENT_LIST_DIR}/src/board_${TARGET_MCU}.c)
+if(NOT EXISTS ${BOARD_FILE})
+    message(FATAL_ERROR
+        "LightBar has no board implementation for MCU '${TARGET_MCU}'. "
+        "Expected: ${BOARD_FILE}")
+endif()
+
+add_peripheral(
+    NAME    lightbar
+    MCU     ${TARGET_MCU}
+    SOURCES src/main.c ${BOARD_FILE}
+)
+target_include_directories(lightbar PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/Peripherals/LightBar/src/board.h
+++ b/Peripherals/LightBar/src/board.h
@@ -1,0 +1,30 @@
+#ifndef LIGHTBAR_BOARD_H
+#define LIGHTBAR_BOARD_H
+
+#include <stdint.h>
+
+#define BOARD_ADDR        0x04
+
+#define BOARD_PIN_LED     16              /* SK6812 data line */
+#define BOARD_NUM_PIXELS  32
+
+/* Lighting modes (matches RS485_PERIPHERAL_BUS.md §LightBar SET_PARAM) */
+#define LB_MODE_SOLID     0
+#define LB_MODE_FLASH     1
+#define LB_MODE_BREATHE   2
+
+#define LB_PARAM_MODE     0x01
+#define LB_PARAM_COLOUR   0x02
+
+/* Hardware-agnostic API. Per-MCU impl in src/board_<mcu>.c. */
+void     board_init(void);
+void     board_set_brightness(uint8_t b);
+uint8_t  board_get_brightness(void);
+void     board_set_mode(uint8_t mode);
+uint8_t  board_get_mode(void);
+void     board_set_colour_rgb16(uint16_t rgb16);   /* RRRRRGGGGGGBBBBB */
+uint16_t board_get_colour_rgb16(void);
+void     board_tick(void);                          /* called from main loop */
+uint16_t board_estimate_power_mw(void);
+
+#endif

--- a/Peripherals/LightBar/src/board_rp2040.c
+++ b/Peripherals/LightBar/src/board_rp2040.c
@@ -1,0 +1,27 @@
+#include "board.h"
+
+#include "pico/stdlib.h"
+
+/* v1: tracks state and exposes a power estimate. The actual SK6812 PIO
+   drive is left to a follow-up — the framework integration is the point
+   of this app. */
+
+static uint8_t  s_brightness;
+static uint8_t  s_mode;
+static uint16_t s_colour;
+
+void     board_init(void)                         { gpio_init(BOARD_PIN_LED); }
+void     board_set_brightness(uint8_t b)          { s_brightness = b; }
+uint8_t  board_get_brightness(void)               { return s_brightness; }
+void     board_set_mode(uint8_t m)                { s_mode = m; }
+uint8_t  board_get_mode(void)                     { return s_mode; }
+void     board_set_colour_rgb16(uint16_t c)       { s_colour = c; }
+uint16_t board_get_colour_rgb16(void)             { return s_colour; }
+void     board_tick(void)                         { /* push pixels here */ }
+
+uint16_t board_estimate_power_mw(void)
+{
+    /* Rough: ~60 mW per LED at full white, scaled by current brightness. */
+    uint32_t mw = (uint32_t)BOARD_NUM_PIXELS * 60u * s_brightness / 255u;
+    return mw > 0xFFFFu ? 0xFFFFu : (uint16_t)mw;
+}

--- a/Peripherals/LightBar/src/main.c
+++ b/Peripherals/LightBar/src/main.c
@@ -1,0 +1,71 @@
+#include "rs485_slave.h"
+#include "board.h"
+
+static int h_set_output(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)r; (void)rs;
+    if (n != 2) return -1;
+    if (p[0] == 0) board_set_brightness(p[1]);
+    return 0;
+}
+
+static int h_set_param(const uint8_t *p, uint8_t n,
+                       uint8_t *r, uint8_t rs)
+{
+    (void)r; (void)rs;
+    if (n != 3) return -1;
+    uint16_t v = (uint16_t)(p[1] | (p[2] << 8));
+    switch (p[0]) {
+    case LB_PARAM_MODE:   board_set_mode((uint8_t)v); break;
+    case LB_PARAM_COLOUR: board_set_colour_rgb16(v);  break;
+    default: return -1;
+    }
+    return 0;
+}
+
+static int h_get_status(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)p; (void)n;
+    if (rs < 4) return -1;
+    r[0] = board_get_brightness();
+    r[1] = board_get_mode();
+    uint16_t c = board_get_colour_rgb16();
+    r[2] = (uint8_t)(c & 0xFF);
+    r[3] = (uint8_t)(c >> 8);
+    return 4;
+}
+
+static int build_stream(uint8_t *buf, uint8_t buf_size)
+{
+    if (buf_size < 2) return -1;
+    uint16_t mw = board_estimate_power_mw();
+    buf[0] = (uint8_t)(mw & 0xFF);
+    buf[1] = (uint8_t)(mw >> 8);
+    return 2;
+}
+
+static const rs485_handler_t s_handlers[] = {
+    { RS485_CMD_SET_OUTPUT, h_set_output },
+    { RS485_CMD_SET_PARAM,  h_set_param  },
+    { RS485_CMD_GET_STATUS, h_get_status },
+    { 0, NULL }
+};
+
+int main(void)
+{
+    board_init();
+    rs485_slave_cfg_t cfg = {
+        .addr        = BOARD_ADDR,
+        .fw_version  = 1,
+        .handlers    = s_handlers,
+        .build_stream = build_stream,
+    };
+    rs485_slave_init(&cfg);
+
+    while (1) {
+        rs485_slave_poll();
+        board_tick();
+    }
+}

--- a/Peripherals/PanTilt/CMakeLists.txt
+++ b/Peripherals/PanTilt/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT DEFINED TARGET_MCU)
+    set(TARGET_MCU rp2040 CACHE STRING "Target MCU (rp2040 | stm32g0 | esp32)")
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../Framework/cmake/framework.cmake)
+
+project(pantilt C ASM)
+
+set(BOARD_FILE ${CMAKE_CURRENT_LIST_DIR}/src/board_${TARGET_MCU}.c)
+if(NOT EXISTS ${BOARD_FILE})
+    message(FATAL_ERROR
+        "PanTilt has no board implementation for MCU '${TARGET_MCU}'. "
+        "Expected: ${BOARD_FILE}")
+endif()
+
+add_peripheral(
+    NAME    pantilt
+    MCU     ${TARGET_MCU}
+    SOURCES src/main.c ${BOARD_FILE}
+)
+target_include_directories(pantilt PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/Peripherals/PanTilt/src/board.h
+++ b/Peripherals/PanTilt/src/board.h
@@ -1,0 +1,17 @@
+#ifndef PANTILT_BOARD_H
+#define PANTILT_BOARD_H
+
+#include <stdint.h>
+
+#define BOARD_ADDR        0x03
+
+/* Two servo PWM outputs. RP2040 default — STM32/ESP32 ports remap. */
+#define BOARD_PIN_SERVO_PAN   14
+#define BOARD_PIN_SERVO_TILT  15
+
+void    board_init(void);
+void    board_set_angle(uint8_t channel, uint8_t deg);   /* 0..180 */
+uint8_t board_get_angle(uint8_t channel);
+uint8_t board_is_moving(void);
+
+#endif

--- a/Peripherals/PanTilt/src/board_rp2040.c
+++ b/Peripherals/PanTilt/src/board_rp2040.c
@@ -1,0 +1,42 @@
+#include "board.h"
+
+#include "pico/stdlib.h"
+#include "hardware/pwm.h"
+
+static uint8_t s_angle[2];
+
+static void servo_init_pin(uint pin)
+{
+    /* 50 Hz PWM, 20 ms period. Pulse width 1.0–2.0 ms = 0–180°.
+       Wrap = 25000 with clkdiv = 100 → tick = 1 µs at 125 MHz. */
+    gpio_set_function(pin, GPIO_FUNC_PWM);
+    uint slice = pwm_gpio_to_slice_num(pin);
+    pwm_set_clkdiv(slice, 100.0f);
+    pwm_set_wrap(slice, 25000);
+    pwm_set_chan_level(slice, pwm_gpio_to_channel(pin), 1500);
+    pwm_set_enabled(slice, true);
+}
+
+static void servo_set(uint pin, uint8_t deg)
+{
+    if (deg > 180) deg = 180;
+    uint16_t us = 1000 + (uint16_t)(((uint32_t)deg * 1000) / 180);
+    pwm_set_chan_level(pwm_gpio_to_slice_num(pin),
+                       pwm_gpio_to_channel(pin), us);
+}
+
+void board_init(void)
+{
+    servo_init_pin(BOARD_PIN_SERVO_PAN);
+    servo_init_pin(BOARD_PIN_SERVO_TILT);
+}
+
+void board_set_angle(uint8_t ch, uint8_t deg)
+{
+    if (ch > 1) return;
+    s_angle[ch] = deg;
+    servo_set(ch == 0 ? BOARD_PIN_SERVO_PAN : BOARD_PIN_SERVO_TILT, deg);
+}
+
+uint8_t board_get_angle(uint8_t ch) { return ch < 2 ? s_angle[ch] : 0; }
+uint8_t board_is_moving(void)        { return 0; }

--- a/Peripherals/PanTilt/src/main.c
+++ b/Peripherals/PanTilt/src/main.c
@@ -1,0 +1,38 @@
+#include "rs485_slave.h"
+#include "board.h"
+
+static int h_set_output(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)r; (void)rs;
+    if (n != 2) return -1;
+    board_set_angle(p[0], p[1]);
+    return 0;
+}
+
+static int h_get_status(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)p; (void)n;
+    if (rs < 3) return -1;
+    r[0] = board_get_angle(0);
+    r[1] = board_get_angle(1);
+    r[2] = board_is_moving();
+    return 3;
+}
+
+static const rs485_handler_t s_handlers[] = {
+    { RS485_CMD_SET_OUTPUT, h_set_output },
+    { RS485_CMD_GET_STATUS, h_get_status },
+    { 0, NULL }
+};
+
+int main(void)
+{
+    board_init();
+    rs485_slave_cfg_t cfg = {
+        .addr = BOARD_ADDR, .fw_version = 1, .handlers = s_handlers,
+    };
+    rs485_slave_init(&cfg);
+    while (1) rs485_slave_poll();
+}

--- a/Peripherals/Searchlight/CMakeLists.txt
+++ b/Peripherals/Searchlight/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT DEFINED TARGET_MCU)
+    set(TARGET_MCU rp2040 CACHE STRING "Target MCU (rp2040 | stm32g0 | esp32)")
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../Framework/cmake/framework.cmake)
+
+project(searchlight C ASM)
+
+set(BOARD_FILE ${CMAKE_CURRENT_LIST_DIR}/src/board_${TARGET_MCU}.c)
+if(NOT EXISTS ${BOARD_FILE})
+    message(FATAL_ERROR
+        "Searchlight has no board implementation for MCU '${TARGET_MCU}'. "
+        "Expected: ${BOARD_FILE}")
+endif()
+
+add_peripheral(
+    NAME    searchlight
+    MCU     ${TARGET_MCU}
+    SOURCES src/main.c ${BOARD_FILE}
+)
+target_include_directories(searchlight PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/Peripherals/Searchlight/src/board.h
+++ b/Peripherals/Searchlight/src/board.h
@@ -1,0 +1,31 @@
+#ifndef SEARCHLIGHT_BOARD_H
+#define SEARCHLIGHT_BOARD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Hardware-agnostic board API. Implementations live in
+   src/board_<mcu>.c and are selected by the app's CMakeLists.txt. */
+
+#define BOARD_ADDR        0x01
+
+/* Searchlight has one PWM-driven LED + an NTC for thermal monitoring. */
+#define BOARD_PIN_PWM     15      /* MOSFET gate */
+#define BOARD_PIN_NTC_ADC 26      /* GP26 = ADC0 */
+
+/* Fault flag bits (matches RS485_PERIPHERAL_BUS.md §Searchlight) */
+#define FAULT_OVERCURRENT     (1u << 0)
+#define FAULT_OVERTEMP        (1u << 1)
+#define FAULT_VBAT_UV         (1u << 2)
+
+/* Thermal shutoff threshold; can be overridden at runtime via SET_PARAM. */
+#define BOARD_OVERTEMP_C      80
+
+void    board_init(void);
+void    board_set_pwm(uint8_t duty);
+uint8_t board_get_pwm(void);
+int8_t  board_read_temp_c(void);
+uint8_t board_fault_flags(void);
+bool    board_overtemp(void);
+
+#endif

--- a/Peripherals/Searchlight/src/board_rp2040.c
+++ b/Peripherals/Searchlight/src/board_rp2040.c
@@ -1,0 +1,41 @@
+#include "board.h"
+
+#include "pico/stdlib.h"
+#include "hardware/pwm.h"
+#include "hardware/adc.h"
+
+static uint8_t s_duty;
+
+void board_init(void)
+{
+    gpio_set_function(BOARD_PIN_PWM, GPIO_FUNC_PWM);
+    uint slice = pwm_gpio_to_slice_num(BOARD_PIN_PWM);
+    pwm_set_wrap(slice, 255);
+    pwm_set_chan_level(slice, pwm_gpio_to_channel(BOARD_PIN_PWM), 0);
+    pwm_set_enabled(slice, true);
+
+    adc_init();
+    adc_gpio_init(BOARD_PIN_NTC_ADC);
+    adc_select_input(0);
+}
+
+void board_set_pwm(uint8_t duty)
+{
+    s_duty = duty;
+    pwm_set_chan_level(pwm_gpio_to_slice_num(BOARD_PIN_PWM),
+                       pwm_gpio_to_channel(BOARD_PIN_PWM), duty);
+}
+
+uint8_t board_get_pwm(void) { return s_duty; }
+
+int8_t board_read_temp_c(void)
+{
+    uint16_t raw = adc_read();          /* 0..4095 */
+    int32_t  c   = 25 + ((2048 - (int32_t)raw) * 60) / 2048;
+    if (c < -40) c = -40;
+    if (c > 125) c = 125;
+    return (int8_t)c;
+}
+
+bool    board_overtemp(void)    { return board_read_temp_c() >= BOARD_OVERTEMP_C; }
+uint8_t board_fault_flags(void) { return board_overtemp() ? FAULT_OVERTEMP : 0; }

--- a/Peripherals/Searchlight/src/main.c
+++ b/Peripherals/Searchlight/src/main.c
@@ -1,0 +1,55 @@
+#include "rs485_slave.h"
+#include "board.h"
+
+/* Portable across all MCUs — board.h hides the hardware. The matching
+   board_<mcu>.c is selected by the app's CMakeLists.txt. */
+
+static int h_set_output(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)r; (void)rs;
+    if (n != 2) return -1;
+    if (p[0] == 0) board_set_pwm(p[1]);   /* channel 0 = brightness */
+    return 0;
+}
+
+static int h_get_status(const uint8_t *p, uint8_t n,
+                        uint8_t *r, uint8_t rs)
+{
+    (void)p; (void)n;
+    if (rs < 3) return -1;
+    r[0] = board_get_pwm();
+    r[1] = (uint8_t)board_read_temp_c();
+    r[2] = board_fault_flags();
+    return 3;
+}
+
+static const rs485_handler_t s_handlers[] = {
+    { RS485_CMD_SET_OUTPUT, h_set_output },
+    { RS485_CMD_GET_STATUS, h_get_status },
+    { 0, NULL }
+};
+
+int main(void)
+{
+    board_init();
+
+    rs485_slave_cfg_t cfg = {
+        .addr        = BOARD_ADDR,
+        .fw_version  = 1,
+        .handlers    = s_handlers,
+        .build_stream = NULL,
+    };
+    rs485_slave_init(&cfg);
+
+    bool int_asserted = false;
+    while (1) {
+        rs485_slave_poll();
+
+        bool ot = board_overtemp();
+        if (ot != int_asserted) {
+            rs485_slave_assert_int(ot);
+            int_asserted = ot;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Reusable slave-side library for the RS-485 peripheral bus, the counterpart to the master in `GCS/src/rs485.c`. Targets RP2040, STM32G031, and ESP32 from the same source tree via a small HAL split (8 functions).
- Portable core (`Peripherals/Framework/core`) with framing FSM, CRC, dispatch, PING/PONG, STREAM scheduling, and `/INT`. No MCU-specific includes — verified by compiling with `-Wall -Wextra -Werror -ffreestanding` against a stub HAL.
- Three example apps with portable `main.c` + per-MCU `board_<mcu>.c`: **Searchlight** (`0x01`), **PanTilt** (`0x03`), **LightBar** (`0x04`). RP2040 board impls included; STM32/ESP32 board impls deferred (CMakeLists hard-fail with a clear message if you target an unsupported MCU).
- Spec copied to `Peripherals/Docs/RS485_PERIPHERAL_BUS.md`. No edits to existing GCS code.

## Test plan
- [x] Core + each app's portable `main.c` compile cleanly under `gcc -Wall -Wextra -Werror -std=c11 -ffreestanding` against a stub HAL.
- [ ] Build matrix on real toolchains: `cmake -B build -DTARGET_MCU=rp2040 …` for each app; produces `*.uf2`.
- [ ] STM32G031: `arm-none-eabi-gcc` build via FetchContent of CMSIS_5 + cmsis_device_g0; produces `*.elf` < 16 KB flash.
- [ ] ESP32: ESP-IDF v5.x build of the framework as a component.
- [ ] Loopback against the GCS master: PING/PONG visible within 1 s, `SET_OUTPUT 0,128` round-trips and changes PWM duty.
- [ ] `/INT` flow: synthetic over-temp on Searchlight pulls `/INT` low and surfaces an `ERROR` over CDC.
- [ ] STREAM_ON 200 ms to LightBar: `STREAM_DATA` frames every ~200 ms with no bus collisions.
- [ ] Multi-slave bus: all three peripherals on one bus, PING latency < 50 ms each.

> Note: signed off as unsigned commit (signing service returned 400 "missing source" on every attempt during the session). Re-sign before merge if branch protection requires it.

https://claude.ai/code/session_01GYeKQ8BH8m5P2zoSyTkvjn